### PR TITLE
feat(main-pane): add table context menu

### DIFF
--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -1,0 +1,3 @@
+## Context Menu
+
+Disabled options trigger hover of components below the context menu.

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -1,3 +1,7 @@
 ## Outcome System
 
 - Move Queue related Outcomes from `PlaybackOutcome` enum to its own `QueueOutcome` enum.
+
+## UI Theme
+
+- Add shadow sizing and palette values

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -4,4 +4,5 @@
 
 ## UI Theme
 
-- Add shadow sizing and palette values
+- Add shadow sizing and palette values.
+- Add sizing for 6.0 pixels.

--- a/docs/todo-v2.md
+++ b/docs/todo-v2.md
@@ -1,0 +1,3 @@
+## Custom Table Widget
+
+- Add click event reporting with `TableArea` to determine what `ContextMenu` component should render on right click.

--- a/src/outcome.rs
+++ b/src/outcome.rs
@@ -4,7 +4,7 @@ use tracing::instrument;
 use crate::{
     app::{App, Message},
     error::AppError,
-    playback::controller::PlaybackControllerStatus,
+    playback::{controller::PlaybackControllerStatus, queue::entry::PlaybackQueueEntryId},
     track::models::TrackId,
 };
 
@@ -26,9 +26,10 @@ pub enum PlaybackOutcome {
     },
     PlayNext,
     PlayPrevious,
-    PlayQueueEntry(u64),
+    PlayQueueEntry(PlaybackQueueEntryId),
     CycleRepeatMode,
     CycleOrder,
+    QueueNext(Vec<TrackId>),
 }
 
 impl App {
@@ -112,6 +113,18 @@ impl App {
             }
             PlaybackOutcome::CycleOrder => {
                 self.playback_queue.cycle_queue_order();
+            }
+            PlaybackOutcome::QueueNext(queued_track_ids) => {
+                for queued_track_id in queued_track_ids {
+                    if self.playback_queue.entries.is_empty() {
+                        self.playback_queue
+                            .start(self.displayed_track_ids.clone(), Some(queued_track_id));
+
+                        self.current_playing_track_id = Some(queued_track_id);
+                    } else {
+                        self.playback_queue.insert_next(queued_track_id);
+                    }
+                }
             }
         }
 

--- a/src/ui/components/main_pane/handler.rs
+++ b/src/ui/components/main_pane/handler.rs
@@ -22,7 +22,7 @@ impl App {
     }
 
     pub fn handle_main_pane(&mut self, message: Message) -> Task<app::Message> {
-        let (task, outcomes) = self.main_pane.update(message);
+        let (task, outcomes) = self.main_pane.update(message, &self.displayed_track_ids);
         let component_task = task.map(app::Message::MainPane);
 
         if outcomes.is_empty() {

--- a/src/ui/components/main_pane/mod.rs
+++ b/src/ui/components/main_pane/mod.rs
@@ -1,7 +1,8 @@
 use iced::{
     Element, Length, Renderer, Task, alignment,
-    widget::{Space, container, text},
+    widget::{Space, button, column, container, text},
 };
+use iced_aw::ContextMenu;
 use iced_palace::widget::ellipsized_text;
 use rustc_hash::{FxHashMap, FxHashSet};
 use tracing::instrument;
@@ -11,11 +12,11 @@ use crate::{
     outcome::PlaybackOutcome,
     track::models::{Track, TrackId},
     ui::{
-        theme::Theme,
+        theme::{Theme, catalog},
         utils::label::format_duration,
         widgets::{
             icons::{self, icon},
-            table::{column, table},
+            table::{self, table},
         },
     },
 };
@@ -89,7 +90,7 @@ impl MainPane {
         let current_playing_track_id = current_playing_track_id.copied().unwrap_or(-1);
 
         let columns = vec![
-            column(TrackTableColumn::NowPlaying, None, move |track: &Track| {
+            table::column(TrackTableColumn::NowPlaying, None, move |track: &Track| {
                 if track.id == current_playing_track_id {
                     icon(icons::PLAY).into()
                 } else {
@@ -97,7 +98,7 @@ impl MainPane {
                 }
             })
             .width(30.0),
-            column(
+            table::column(
                 TrackTableColumn::Artist,
                 Some(text("Artist").into()),
                 |track: &Track| {
@@ -107,7 +108,7 @@ impl MainPane {
             )
             .width(200.0)
             .resizable(true),
-            column(
+            table::column(
                 TrackTableColumn::Title,
                 Some(text("Title").into()),
                 |track: &Track| {
@@ -117,7 +118,7 @@ impl MainPane {
             )
             .width(200.0)
             .resizable(true),
-            column(
+            table::column(
                 TrackTableColumn::Duration,
                 Some(text("Duration").into()),
                 |track: &Track| {
@@ -132,7 +133,7 @@ impl MainPane {
             .align_x(alignment::Horizontal::Right),
         ];
 
-        container(
+        container(ContextMenu::new(
             table(
                 columns,
                 displayed_track_ids
@@ -144,7 +145,17 @@ impl MainPane {
             .on_row_select(Message::TrackRowSelected)
             .on_row_double_click(Message::TrackRowDoubleClicked)
             .on_header_cell_click(Message::ColumnHeaderCellClicked),
-        )
+            || {
+                if self.selected_track_ids.is_empty() {
+                    Space::new().into()
+                } else {
+                    container(column![Space::new().width(100.0).height(100.0)])
+                        .padding(4.0)
+                        .style(catalog::container::context_menu)
+                        .into()
+                }
+            },
+        ))
         .height(Length::Fill)
         .width(Length::Fill)
         .style(|theme: &Theme| container::Style {

--- a/src/ui/components/main_pane/mod.rs
+++ b/src/ui/components/main_pane/mod.rs
@@ -1,6 +1,6 @@
 use iced::{
     Element, Length, Renderer, Task, alignment,
-    widget::{Space, button, column, container, text},
+    widget::{Space, column, container, text},
 };
 use iced_aw::ContextMenu;
 use iced_palace::widget::ellipsized_text;
@@ -16,6 +16,7 @@ use crate::{
         utils::label::format_duration,
         widgets::{
             icons::{self, icon},
+            menu::menu_option,
             table::{self, table},
         },
     },
@@ -26,15 +27,14 @@ pub mod handler;
 #[derive(Debug, Default)]
 pub struct MainPane {
     pub selected_track_ids: FxHashSet<i64>,
-    pub displayed_track_ids: Vec<TrackId>,
 }
 
 #[derive(Debug, Clone)]
 pub enum Message {
-    SetDisplayedTracks(Vec<TrackId>),
     TrackRowDoubleClicked(TrackId),
     TrackRowSelected(FxHashSet<TrackId>),
     ColumnHeaderCellClicked(TrackTableColumn),
+    QueueNext,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -55,14 +55,15 @@ pub struct MainPaneUpdateContext {}
 
 impl MainPane {
     #[instrument(skip(self), level = "debug")]
-    pub fn update(&mut self, event: Message) -> (Task<Message>, Vec<Outcome>) {
+    pub fn update(
+        &mut self,
+        event: Message,
+        displayed_track_ids: &Vec<TrackId>,
+    ) -> (Task<Message>, Vec<Outcome>) {
         let task = Task::none();
         let mut outcomes = Vec::new();
 
         match event {
-            Message::SetDisplayedTracks(displayed_track_ids) => {
-                self.displayed_track_ids = displayed_track_ids;
-            }
             Message::TrackRowDoubleClicked(track_id) => {
                 outcomes.push(Outcome::Playback(PlaybackOutcome::StartQueue(track_id)));
             }
@@ -70,6 +71,19 @@ impl MainPane {
                 self.selected_track_ids = selected_track_ids.into_iter().collect();
             }
             Message::ColumnHeaderCellClicked(_column_id) => {}
+            Message::QueueNext => {
+                if !self.selected_track_ids.is_empty() {
+                    let queued_track_ids = displayed_track_ids
+                        .iter()
+                        .filter(|track_id| self.selected_track_ids.contains(track_id))
+                        .copied()
+                        .collect();
+
+                    outcomes.push(Outcome::Playback(PlaybackOutcome::QueueNext(
+                        queued_track_ids,
+                    )));
+                }
+            }
         }
 
         (task, outcomes)
@@ -149,10 +163,17 @@ impl MainPane {
                 if self.selected_track_ids.is_empty() {
                     Space::new().into()
                 } else {
-                    container(column![Space::new().width(100.0).height(100.0)])
-                        .padding(4.0)
-                        .style(catalog::container::context_menu)
-                        .into()
+                    container(
+                        column![
+                            menu_option("Queue Next", Some(Message::QueueNext)),
+                            menu_option("Tag Selection", None)
+                        ]
+                        .width(Length::Fill),
+                    )
+                    .width(180.0)
+                    .padding(6.0)
+                    .style(catalog::container::context_menu)
+                    .into()
                 }
             },
         ))

--- a/src/ui/theme/catalog/button.rs
+++ b/src/ui/theme/catalog/button.rs
@@ -1,9 +1,10 @@
 use iced::{
-    Border,
+    Background, Border,
+    border::Radius,
     widget::button::{Catalog, Status, Style},
 };
 
-use crate::ui::theme::Theme;
+use crate::ui::theme::{Theme, color::lighten};
 
 pub type StyleFn<'a> = Box<dyn Fn(&Theme, Status) -> Style + 'a>;
 
@@ -34,5 +35,28 @@ impl Catalog for Theme {
 
     fn style(&self, class: &Self::Class<'_>, status: Status) -> Style {
         class(self, status)
+    }
+}
+
+pub fn menu_option(theme: &Theme, status: Status) -> Style {
+    let background: Option<Background> = match status {
+        Status::Active | Status::Disabled => None,
+        Status::Pressed => Some(lighten(theme.palette.hover, 0.1).into()),
+        Status::Hovered => Some(theme.palette.hover.into()),
+    };
+
+    let text_color = match status {
+        Status::Active | Status::Hovered | Status::Pressed => theme.palette.text,
+        Status::Disabled => theme.palette.text_muted,
+    };
+
+    Style {
+        background,
+        text_color,
+        border: Border {
+            radius: Radius::from(theme.sizes.border.radius_sm),
+            ..Border::default()
+        },
+        ..Style::default()
     }
 }

--- a/src/ui/theme/catalog/container.rs
+++ b/src/ui/theme/catalog/container.rs
@@ -1,5 +1,6 @@
 use iced::{
-    Border,
+    Border, Color, Shadow, Vector,
+    border::Radius,
     widget::container::{Catalog, Style},
 };
 
@@ -19,28 +20,20 @@ impl Catalog for Theme {
     }
 }
 
-pub fn pane<'a>() -> StyleFn<'a> {
-    Box::new(|theme: &Theme| Style {
+pub fn context_menu(theme: &Theme) -> Style {
+    Style {
         background: Some(theme.palette.surface_raised.into()),
         text_color: None,
         border: Border {
             color: theme.palette.border,
             width: theme.sizes.border.width,
-            radius: theme.sizes.border.radius_md.into(),
+            radius: Radius::from(theme.sizes.border.radius_md),
+        },
+        shadow: Shadow {
+            color: Color::BLACK,
+            blur_radius: theme.sizes.border.radius_md,
+            offset: Vector::new(theme.sizes.space.sm, theme.sizes.space.sm),
         },
         ..Style::default()
-    })
-}
-
-pub fn header<'a>() -> StyleFn<'a> {
-    Box::new(|theme: &Theme| Style {
-        background: Some(theme.palette.surface_raised.into()),
-        text_color: None,
-        border: Border {
-            color: theme.palette.border,
-            width: theme.sizes.border.width,
-            ..Border::default()
-        },
-        ..Style::default()
-    })
+    }
 }

--- a/src/ui/theme/catalog/context_menu.rs
+++ b/src/ui/theme/catalog/context_menu.rs
@@ -1,0 +1,20 @@
+use iced::{Background, Color};
+use iced_aw::context_menu::{Catalog, Status, Style};
+
+use crate::ui::theme::Theme;
+
+pub type StyleFn<'a> = Box<dyn Fn(&Theme, Status) -> Style + 'a>;
+
+impl Catalog for Theme {
+    type Class<'a> = StyleFn<'a>;
+
+    fn default<'a>() -> Self::Class<'a> {
+        Box::new(|_theme, _status| Style {
+            background: Background::Color(Color::TRANSPARENT),
+        })
+    }
+
+    fn style(&self, class: &Self::Class<'_>, status: Status) -> Style {
+        class(self, status)
+    }
+}

--- a/src/ui/theme/catalog/mod.rs
+++ b/src/ui/theme/catalog/mod.rs
@@ -1,6 +1,7 @@
 pub mod application;
 pub mod button;
 pub mod container;
+pub mod context_menu;
 pub mod menu_bar;
 pub mod scrollable;
 pub mod slider;

--- a/src/ui/widgets/menu.rs
+++ b/src/ui/widgets/menu.rs
@@ -1,7 +1,10 @@
-use iced::{widget::button, Element, Renderer};
-use iced_aw::{menu::Item, Menu, MenuBar};
+use iced::{
+    Element, Length, Renderer,
+    widget::{Button, button, text},
+};
+use iced_aw::{Menu, MenuBar, menu::Item};
 
-use crate::ui::theme::Theme;
+use crate::ui::theme::{Theme, catalog};
 
 pub type DropdownMenuToggle<'a, M> = MenuBar<'a, M, Theme, Renderer>;
 pub type DropdownMenuItem<'a, M> = Item<'a, M, Theme, Renderer>;
@@ -51,4 +54,17 @@ pub fn dropdown_menu_grouping_option<'a, M: Clone + 'a>(
     submenu: DropdownMenu<'a, M>,
 ) -> DropdownMenuItem<'a, M> {
     Item::with_menu(button(label), submenu)
+}
+
+pub fn menu_option<'a, Message>(
+    text_label: &'static str,
+    on_press: Option<Message>,
+) -> Button<'a, Message, Theme, Renderer>
+where
+    Message: Clone + 'a,
+{
+    button(text(text_label))
+        .on_press_maybe(on_press)
+        .width(Length::Fill)
+        .style(catalog::button::menu_option)
 }

--- a/src/ui/widgets/table/event/mouse.rs
+++ b/src/ui/widgets/table/event/mouse.rs
@@ -183,7 +183,13 @@ where
                     TableArea::Body {
                         row_id: Some(row_id),
                     } => {
-                        self.handle_mouse_row_click(state, shell, row_id.clone(), click.kind());
+                        self.handle_mouse_row_selection(
+                            state,
+                            shell,
+                            row_id.clone(),
+                            mouse::Button::Left,
+                            click.kind(),
+                        );
                     }
                     TableArea::Scroll {
                         scroll_area_offset: Some(scroll_area_offset),
@@ -200,6 +206,24 @@ where
                 }
             }
 
+            mouse::Button::Right => {
+                let Some(clicked_area) = state.mouse_interaction.area.as_ref() else {
+                    return;
+                };
+
+                if let TableArea::Body {
+                    row_id: Some(row_id),
+                } = clicked_area
+                {
+                    self.handle_mouse_row_selection(
+                        state,
+                        shell,
+                        row_id.clone(),
+                        mouse::Button::Right,
+                        click.kind(),
+                    );
+                }
+            }
             _ => {}
         }
     }

--- a/src/ui/widgets/table/event/select.rs
+++ b/src/ui/widgets/table/event/select.rs
@@ -30,13 +30,22 @@ where
         }
     }
 
-    pub fn handle_mouse_row_click(
+    pub fn handle_mouse_row_selection(
         &self,
         state: &mut State<T::Identifier, ColumnId>,
         shell: &mut Shell<'_, Message>,
         row_id: T::Identifier,
+        button: mouse::Button,
         click_kind: click::Kind,
     ) {
+        if matches!(button, mouse::Button::Right)
+            && self
+                .selected_rows
+                .is_some_and(|selected_rows| selected_rows.contains(&row_id))
+        {
+            return;
+        }
+
         if let Some(on_row_select) = self.on_row_select.as_ref() {
             let empty_selection = FxHashSet::default();
             let selected_rows = self.selected_rows.unwrap_or(&empty_selection);
@@ -60,7 +69,10 @@ where
         }
 
         if let Some(on_row_double_click) = self.on_row_double_click.as_ref()
-            && matches!(click_kind, click::Kind::Double)
+            && matches!(
+                (button, click_kind),
+                (mouse::Button::Left, click::Kind::Double)
+            )
         {
             shell.publish(on_row_double_click(row_id));
             shell.capture_event();


### PR DESCRIPTION
## Changes

- Added right click behavior for table body, right clicking outside a selection triggers a normal selection with modifiers.
- Added context menu to main pane table, it contains at the moment two options:
  - Queue Next: Takes the current selection and queues it next in order of display. starting a queue if there is none.
  - Tag Selection: Manage Track Modals entry point in the future.

## Known issues

- Disabled context menu options trigger hover of elements below.

## Additional notes

- Context menu attempts to open on any right click made to the table, deferred detecting where the click happens for v2.

## Screenshot
<img width="351" height="146" alt="image" src="https://github.com/user-attachments/assets/df5638eb-37b2-4826-90b6-412dbb44e9ac" />
