### PR TITLE
feat(manage-tags): add tag management modal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,6 +321,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93ebbf82d06013f4c41fe71303feb980cddd78496d904d06be627972de51a24"
 
 [[package]]
+name = "audio_thread_priority"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7203799cd8063907524460aa8b632a46baba80c50947295aa6b92d7793c26447"
+dependencies = [
+ "cfg-if",
+ "dbus",
+ "libc",
+ "log",
+ "mach2 0.4.3",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "audioadapter"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -780,12 +794,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8942da362c0f0d895d7cac616263f2f9424edc5687364dfd1d25ef7eba506d7"
 dependencies = [
  "alsa",
+ "audio_thread_priority",
  "coreaudio-rs",
  "dasp_sample",
  "jni 0.21.1",
  "js-sys",
  "libc",
- "mach2",
+ "mach2 0.5.0",
  "ndk",
  "ndk-context",
  "num-derive",
@@ -971,6 +986,16 @@ name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
+
+[[package]]
+name = "dbus"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48b5f0f36f1eebe901b0e6bee369a77ed3396334bf3f09abd46454a576f71819"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+]
 
 [[package]]
 name = "der"
@@ -2380,6 +2405,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2486,6 +2520,15 @@ dependencies = [
  "cc",
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ tracing = { version = "0.1.44", features = ["max_level_trace", "release_max_leve
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "fmt"] }
 tracing-appender = "0.2.5"
 dotenvy = "0.15.7"
-cpal = "0.17.3"
+cpal = { version = "0.17.3", features = ["audio_thread_priority"] }
 rtrb = "0.3.4"
 rubato = "3.0.0"
 iced_split = "0.1.0"

--- a/docs/todo-v2.md
+++ b/docs/todo-v2.md
@@ -6,3 +6,9 @@
 
 - Add Keyboard controls guide
 - Add Empty state with call to action that opens Manage Tags modal.
+
+# Tag Management Modal
+
+- Add error handling when trying to add duplicate tags/tag groups.
+- Improve appearance of modal's body
+- Add tag renaming

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use iced_split::{horizontal_split, vertical_split};
+use itertools::Itertools;
 use rustc_hash::FxHashMap;
 use sqlx::SqlitePool;
 
@@ -228,7 +229,18 @@ impl App {
                 self.tracks = tracks.into_iter().map(|track| (track.id, track)).collect();
 
                 // TODO: Add loading state to main pane before setting the displayed tracks
-                self.displayed_track_ids = self.tracks.keys().copied().collect();
+                self.displayed_track_ids = self
+                    .tracks
+                    .iter()
+                    .sorted_by_cached_key(|(_track_id, track)| {
+                        (
+                            track.artist.as_deref().unwrap_or("Unknown").to_lowercase(),
+                            track.title.as_deref().unwrap_or("Untitled").to_lowercase(),
+                        )
+                    })
+                    .map(|(track_id, _track)| track_id)
+                    .copied()
+                    .collect();
 
                 // info!("Tracks loaded successfully");
             }

--- a/src/app.rs
+++ b/src/app.rs
@@ -107,10 +107,15 @@ pub enum Message {
     LoadTracks,
     LoadedTracks(Result<Vec<Track>, AppError>),
     LoadTagLibrary,
+    ReloadTagLibrary,
     LoadedTagLibrary(Result<TagLibrary, AppError>),
     ScanDirectory(Option<Vec<PathBuf>>),
     ScannedDirectory(Result<(), AppError>),
     ToggledTrackTag(Result<(), AppError>),
+    AddedTag(Result<(), AppError>),
+    DeletedTag(Result<(), AppError>),
+    InsertedTagGroup(Result<(), AppError>),
+    DeletedTagGroup(Result<(), AppError>),
 
     AudioPipelineEventChannelReady(
         iced::futures::channel::mpsc::UnboundedSender<AudioPipelineThreadEvent>,
@@ -247,7 +252,7 @@ impl App {
             Message::LoadedTracks(Err(error)) => {
                 error!("Failed to load tracks: {error}");
             }
-            Message::LoadTagLibrary => {
+            Message::LoadTagLibrary | Message::ReloadTagLibrary => {
                 let pool = self.pool.clone();
 
                 task = Task::perform(
@@ -270,6 +275,22 @@ impl App {
             }
             Message::LoadedTagLibrary(Err(error)) => {
                 error!("Failed to load tag library: {error}");
+            }
+            Message::AddedTag(Ok(()))
+            | Message::InsertedTagGroup(Ok(()))
+            | Message::DeletedTag(Ok(()))
+            | Message::DeletedTagGroup(Ok(())) => {}
+            Message::AddedTag(Err(error)) => {
+                error!("Failed to insert tag: {error}");
+            }
+            Message::DeletedTag(Err(error)) => {
+                error!("Failed to delete tag: {error}");
+            }
+            Message::InsertedTagGroup(Err(error)) => {
+                error!("Failed to insert tag group: {error}");
+            }
+            Message::DeletedTagGroup(Err(error)) => {
+                error!("Failed to delete tag: {error}");
             }
             Message::ScanDirectory(Some(directories)) => {
                 let pool = self.pool.clone();

--- a/src/outcome.rs
+++ b/src/outcome.rs
@@ -25,6 +25,7 @@ pub enum Outcome {
 pub enum ModalOutcome {
     CloseModal,
     OpenTagTracksModal(Vec<TrackId>),
+    OpenManageTagsModal,
 }
 
 #[derive(Debug, Clone)]
@@ -196,6 +197,9 @@ impl App {
 
                 self.modal_controller
                     .open_tag_tracks_modal(track_tagging_queue);
+            }
+            ModalOutcome::OpenManageTagsModal => {
+                self.modal_controller.open_manage_tags_modal();
             }
         }
 

--- a/src/outcome.rs
+++ b/src/outcome.rs
@@ -4,11 +4,13 @@ use tracing::{error, instrument, warn};
 use crate::{
     app::{App, Message, PlaybackOwner},
     error::AppError,
-    outcome::TagOutcome::SaveTags,
     playback::{controller::PlaybackControllerStatus, queue::entry::PlaybackQueueEntryId},
     tag::{
-        models::TagId,
-        repository::{delete_track_tag, insert_track_tag},
+        models::{TagGroupId, TagId},
+        repository::{
+            delete_tag, delete_tag_group, delete_track_tag, insert_tag, insert_tag_group,
+            insert_track_tag,
+        },
     },
     track::models::TrackId,
     ui::components::playback_bar::PlaybackBarStatus,
@@ -50,7 +52,10 @@ pub enum PlaybackOutcome {
 #[derive(Debug, Clone)]
 pub enum TagOutcome {
     ToggleTag(TrackId, TagId),
-    SaveTags,
+    AddNewTag(TagGroupId, String),
+    DeleteTag(TagId),
+    AddNewTagGroup(String),
+    DeleteTagGroup(TagGroupId),
 }
 
 impl App {
@@ -230,8 +235,37 @@ impl App {
                     Message::ToggledTrackTag,
                 );
             }
-            SaveTags => {
-                warn!("Saving current track tag index is still not implemented");
+            TagOutcome::AddNewTag(tag_group_id, tag_name) => {
+                let pool = self.pool.clone();
+                task = Task::perform(
+                    async move { insert_tag(pool, tag_group_id, tag_name).await },
+                    Message::AddedTag,
+                )
+                .chain(Task::done(Message::LoadTagLibrary));
+            }
+            TagOutcome::AddNewTagGroup(tag_group_name) => {
+                let pool = self.pool.clone();
+                task = Task::perform(
+                    async move { insert_tag_group(pool, tag_group_name).await },
+                    Message::AddedTag,
+                )
+                .chain(Task::done(Message::LoadTagLibrary));
+            }
+            TagOutcome::DeleteTag(tag_id) => {
+                let pool = self.pool.clone();
+                task = Task::perform(
+                    async move { delete_tag(pool, tag_id).await },
+                    Message::DeletedTag,
+                )
+                .chain(Task::done(Message::LoadTagLibrary));
+            }
+            TagOutcome::DeleteTagGroup(tag_group_id) => {
+                let pool = self.pool.clone();
+                task = Task::perform(
+                    async move { delete_tag_group(pool, tag_group_id).await },
+                    Message::DeletedTagGroup,
+                )
+                .chain(Task::done(Message::LoadTagLibrary));
             }
         }
 

--- a/src/outcome.rs
+++ b/src/outcome.rs
@@ -8,8 +8,8 @@ use crate::{
     tag::{
         models::{TagGroupId, TagId},
         repository::{
-            delete_tag, delete_tag_group, delete_track_tag, insert_tag, insert_tag_group,
-            insert_track_tag,
+            delete_track_tag, insert_tag, insert_tag_group, insert_track_tag, soft_delete_tag,
+            soft_delete_tag_group,
         },
     },
     track::models::TrackId,
@@ -53,9 +53,9 @@ pub enum PlaybackOutcome {
 pub enum TagOutcome {
     ToggleTag(TrackId, TagId),
     AddNewTag(TagGroupId, String),
-    DeleteTag(TagId),
+    RemoveTag(TagId),
     AddNewTagGroup(String),
-    DeleteTagGroup(TagGroupId),
+    RemoveTagGroup(TagGroupId),
 }
 
 impl App {
@@ -251,18 +251,18 @@ impl App {
                 )
                 .chain(Task::done(Message::LoadTagLibrary));
             }
-            TagOutcome::DeleteTag(tag_id) => {
+            TagOutcome::RemoveTag(tag_id) => {
                 let pool = self.pool.clone();
                 task = Task::perform(
-                    async move { delete_tag(pool, tag_id).await },
+                    async move { soft_delete_tag(pool, tag_id).await },
                     Message::DeletedTag,
                 )
                 .chain(Task::done(Message::LoadTagLibrary));
             }
-            TagOutcome::DeleteTagGroup(tag_group_id) => {
+            TagOutcome::RemoveTagGroup(tag_group_id) => {
                 let pool = self.pool.clone();
                 task = Task::perform(
-                    async move { delete_tag_group(pool, tag_group_id).await },
+                    async move { soft_delete_tag_group(pool, tag_group_id).await },
                     Message::DeletedTagGroup,
                 )
                 .chain(Task::done(Message::LoadTagLibrary));

--- a/src/playback/engine/mod.rs
+++ b/src/playback/engine/mod.rs
@@ -7,8 +7,8 @@ use std::{
 };
 
 use cpal::{
-    BuildStreamError, DefaultStreamConfigError, PauseStreamError, PlayStreamError, SampleFormat,
-    Stream, default_host,
+    BufferSize, BuildStreamError, DefaultStreamConfigError, PauseStreamError, PlayStreamError,
+    SampleFormat, Stream, default_host,
     traits::{DeviceTrait, HostTrait},
 };
 use rtrb::{Consumer, PopError};
@@ -146,14 +146,20 @@ impl PlaybackEngine for AudioEngine {
         let device = host
             .default_output_device()
             .ok_or(PlaybackEngineError::OutputDeviceNotFound)?;
-        let config = device.default_output_config()?;
+        let supported_stream_config = device.default_output_config()?;
+        let mut stream_config = supported_stream_config.config();
 
-        let sample_rate = config.sample_rate();
-        let channels = config.channels();
+        #[cfg(target_os = "linux")]
+        {
+            stream_config.buffer_size = BufferSize::Fixed(2048);
+        }
+
+        let sample_rate = supported_stream_config.sample_rate();
+        let channels = supported_stream_config.channels();
 
         let build_arguments = AudioEngineStreamBuildArguments {
             sample_buffer_consumer,
-            config: config.clone().into(),
+            config: stream_config,
             device,
             samples_played,
             track_start_timestamp,
@@ -162,7 +168,7 @@ impl PlaybackEngine for AudioEngine {
             paused: Arc::clone(&self.paused),
         };
 
-        let stream = match config.sample_format() {
+        let stream = match supported_stream_config.sample_format() {
             SampleFormat::F32 => build_output_stream::<f32>(build_arguments)?,
             SampleFormat::I16 => build_output_stream::<i16>(build_arguments)?,
             SampleFormat::U16 => build_output_stream::<u16>(build_arguments)?,

--- a/src/tag/repository/delete.rs
+++ b/src/tag/repository/delete.rs
@@ -5,9 +5,33 @@ use tracing::instrument;
 
 use crate::{
     error::AppError,
-    tag::models::{TagId, TrackTagIden},
+    tag::models::{TagGroupId, TagGroupIden, TagId, TagIden, TrackTagIden},
     track::models::TrackId,
 };
+
+#[instrument(skip(pool))]
+pub async fn delete_tag(pool: SqlitePool, tag_id: TagId) -> Result<(), AppError> {
+    let (sql, values) = Query::delete()
+        .from_table(TagIden::Table)
+        .and_where(Expr::col(TagIden::Id).eq(tag_id))
+        .build_sqlx(SqliteQueryBuilder);
+
+    sqlx::query_with(&sql, values).execute(&pool).await?;
+
+    Ok(())
+}
+
+#[instrument(skip(pool))]
+pub async fn delete_tag_group(pool: SqlitePool, tag_group_id: TagGroupId) -> Result<(), AppError> {
+    let (sql, values) = Query::delete()
+        .from_table(TagGroupIden::Table)
+        .and_where(Expr::col(TagGroupIden::Id).eq(tag_group_id))
+        .build_sqlx(SqliteQueryBuilder);
+
+    sqlx::query_with(&sql, values).execute(&pool).await?;
+
+    Ok(())
+}
 
 #[instrument(skip(pool))]
 pub async fn delete_track_tag(

--- a/src/tag/repository/insert.rs
+++ b/src/tag/repository/insert.rs
@@ -5,9 +5,38 @@ use tracing::instrument;
 
 use crate::{
     error::AppError,
-    tag::models::{TagId, TrackTagIden},
+    tag::models::{TagGroupId, TagGroupIden, TagId, TagIden, TrackTagIden},
     track::models::TrackId,
 };
+
+#[instrument(skip(pool))]
+pub async fn insert_tag(
+    pool: SqlitePool,
+    tag_group_id: TagGroupId,
+    tag_name: String,
+) -> Result<(), AppError> {
+    let (sql, values) = Query::insert()
+        .columns([TagIden::Name, TagIden::TagGroupId])
+        .into_table(TagIden::Table)
+        .values([tag_name.into(), tag_group_id.into()])?
+        .build_sqlx(SqliteQueryBuilder);
+
+    sqlx::query_with(&sql, values).execute(&pool).await?;
+
+    Ok(())
+}
+
+pub async fn insert_tag_group(pool: SqlitePool, tag_group_name: String) -> Result<(), AppError> {
+    let (sql, values) = Query::insert()
+        .columns([TagGroupIden::Name])
+        .into_table(TagGroupIden::Table)
+        .values([tag_group_name.into()])?
+        .build_sqlx(SqliteQueryBuilder);
+
+    sqlx::query_with(&sql, values).execute(&pool).await?;
+
+    Ok(())
+}
 
 #[instrument(skip(pool))]
 pub async fn insert_track_tag(

--- a/src/tag/repository/mod.rs
+++ b/src/tag/repository/mod.rs
@@ -1,7 +1,9 @@
 mod delete;
 mod insert;
 mod select;
+mod update;
 
 pub use delete::*;
 pub use insert::*;
 pub use select::*;
+pub use update::*;

--- a/src/tag/repository/select.rs
+++ b/src/tag/repository/select.rs
@@ -1,4 +1,4 @@
-use sea_query::{Asterisk, Expr, ExprTrait, Query, SqliteQueryBuilder};
+use sea_query::{Asterisk, Expr, ExprTrait, JoinType, Query, SqliteQueryBuilder};
 use sea_query_sqlx::SqlxBinder;
 use sqlx::SqlitePool;
 use tracing::instrument;
@@ -11,9 +11,16 @@ use crate::{
 #[instrument(skip(pool))]
 pub async fn get_tags(pool: SqlitePool) -> Result<Vec<Tag>, AppError> {
     let (sql, values) = Query::select()
-        .column(Asterisk)
+        .column((TagIden::Table, Asterisk))
         .from(TagIden::Table)
-        .and_where(Expr::col(TagIden::DeletedAt).is_null())
+        .join(
+            JoinType::RightJoin,
+            TagGroupIden::Table,
+            Expr::col((TagIden::Table, TagIden::TagGroupId))
+                .equals((TagGroupIden::Table, TagGroupIden::Id)),
+        )
+        .and_where(Expr::col((TagIden::Table, TagIden::DeletedAt)).is_null())
+        .and_where(Expr::col((TagGroupIden::Table, TagGroupIden::DeletedAt)).is_null())
         .build_sqlx(SqliteQueryBuilder);
 
     let tags = sqlx::query_as_with::<_, Tag, _>(&sql, values)

--- a/src/tag/repository/update.rs
+++ b/src/tag/repository/update.rs
@@ -1,0 +1,40 @@
+use sea_query::{Expr, ExprTrait, Query, SqliteQueryBuilder};
+use sea_query_sqlx::SqlxBinder;
+use sqlx::SqlitePool;
+use tracing::instrument;
+
+use crate::{
+    error::AppError,
+    tag::models::{TagGroupId, TagGroupIden, TagId, TagIden},
+};
+
+#[instrument(skip(pool))]
+pub async fn soft_delete_tag(pool: SqlitePool, tag_id: TagId) -> Result<(), AppError> {
+    let (sql, values) = Query::update()
+        .values([(TagIden::DeletedAt, Expr::cust("unixepoch()"))])
+        .table(TagIden::Table)
+        .and_where(Expr::col(TagIden::Id).eq(tag_id))
+        .and_where(Expr::col(TagIden::DeletedAt).is_null())
+        .build_sqlx(SqliteQueryBuilder);
+
+    sqlx::query_with(&sql, values).execute(&pool).await?;
+
+    Ok(())
+}
+
+#[instrument(skip(pool))]
+pub async fn soft_delete_tag_group(
+    pool: SqlitePool,
+    tag_group_id: TagGroupId,
+) -> Result<(), AppError> {
+    let (sql, values) = Query::update()
+        .values([(TagGroupIden::DeletedAt, Expr::cust("unixepoch()"))])
+        .table(TagGroupIden::Table)
+        .and_where(Expr::col(TagGroupIden::Id).eq(tag_group_id))
+        .and_where(Expr::col(TagGroupIden::DeletedAt).is_null())
+        .build_sqlx(SqliteQueryBuilder);
+
+    sqlx::query_with(&sql, values).execute(&pool).await?;
+
+    Ok(())
+}

--- a/src/ui/components/navigation_bar/handler.rs
+++ b/src/ui/components/navigation_bar/handler.rs
@@ -30,6 +30,7 @@ impl App {
         let mut tasks = vec![component_task];
         for outcome in outcomes {
             let outcome_task = match outcome {
+                // TODO: Move this to the outcome system
                 Outcome::OpenSelectDirectoryDialog => Task::perform(
                     async {
                         AsyncFileDialog::new().pick_folders().await.map(|handles| {
@@ -38,6 +39,7 @@ impl App {
                     },
                     app::Message::ScanDirectory,
                 ),
+                Outcome::Modal(outcome) => self.handle_outcome(app::Outcome::Modal(outcome)),
             };
             tasks.push(outcome_task);
         }

--- a/src/ui/components/navigation_bar/mod.rs
+++ b/src/ui/components/navigation_bar/mod.rs
@@ -6,7 +6,7 @@ use tracing::instrument;
 
 use crate::{
     event::Event,
-    ui::{components::navigation_bar::navigation_bar_menu::navigation_bar_menu, theme::Theme},
+    ui::{components::navigation_bar::navigation_bar_menu::main_menu_dropdown, theme::Theme},
 };
 
 pub mod handler;
@@ -42,7 +42,7 @@ impl NavigationBar {
 
     pub fn view<'a>(&'a self, theme: &Theme) -> Element<'a, Message, Theme, Renderer> {
         container(
-            row![navigation_bar_menu(theme)]
+            row![main_menu_dropdown(theme)]
                 .align_y(alignment::Vertical::Center)
                 .padding(Padding::from([0.0, theme.sizes.space.lg]))
                 .height(Length::Fill),

--- a/src/ui/components/navigation_bar/mod.rs
+++ b/src/ui/components/navigation_bar/mod.rs
@@ -1,5 +1,5 @@
 use iced::{
-    Element, Length, Renderer, Task,
+    Element, Length, Padding, Renderer, Task, alignment,
     widget::{container, row},
 };
 use tracing::instrument;
@@ -41,13 +41,18 @@ impl NavigationBar {
     }
 
     pub fn view<'a>(&'a self, theme: &Theme) -> Element<'a, Message, Theme, Renderer> {
-        container(row![navigation_bar_menu(theme)])
-            .height(Length::Fixed(theme.sizes.component.nav_bar_height))
-            .width(Length::Fill)
-            .style(|theme: &Theme| container::Style {
-                background: Some(theme.palette.surface_sunken.into()),
-                ..container::Style::default()
-            })
-            .into()
+        container(
+            row![navigation_bar_menu(theme)]
+                .align_y(alignment::Vertical::Center)
+                .padding(Padding::from([0.0, theme.sizes.space.lg]))
+                .height(Length::Fill),
+        )
+        .height(Length::Fixed(theme.sizes.component.nav_bar_height))
+        .width(Length::Fill)
+        .style(|theme: &Theme| container::Style {
+            background: Some(theme.palette.surface_sunken.into()),
+            ..container::Style::default()
+        })
+        .into()
     }
 }

--- a/src/ui/components/navigation_bar/mod.rs
+++ b/src/ui/components/navigation_bar/mod.rs
@@ -6,6 +6,7 @@ use tracing::instrument;
 
 use crate::{
     event::Event,
+    outcome::ModalOutcome,
     ui::{components::navigation_bar::navigation_bar_menu::main_menu_dropdown, theme::Theme},
 };
 
@@ -18,21 +19,31 @@ pub struct NavigationBar {}
 #[derive(Debug, Clone)]
 pub enum Message {
     SelectedScanDirectoryOption,
+    SelectedEditMenuManageTagsOption,
 }
 
 #[derive(Debug, Clone)]
 pub enum Outcome {
+    Modal(ModalOutcome),
     OpenSelectDirectoryDialog,
 }
 
 impl NavigationBar {
     #[instrument(skip(self), level = "debug")]
     pub fn update(&mut self, event: Message) -> (Task<Message>, Vec<Outcome>) {
+        let task = Task::none();
+        let mut outcomes = Vec::new();
+
         match event {
             Message::SelectedScanDirectoryOption => {
-                (Task::none(), vec![Outcome::OpenSelectDirectoryDialog])
+                outcomes.push(Outcome::OpenSelectDirectoryDialog);
+            }
+            Message::SelectedEditMenuManageTagsOption => {
+                outcomes.push(Outcome::Modal(ModalOutcome::OpenManageTagsModal));
             }
         }
+
+        (task, outcomes)
     }
 
     #[instrument(skip(self), level = "debug")]

--- a/src/ui/components/navigation_bar/navigation_bar_menu.rs
+++ b/src/ui/components/navigation_bar/navigation_bar_menu.rs
@@ -1,8 +1,8 @@
-use iced::{Element, Renderer, widget::button};
+use iced::{Element, Length, Padding, Renderer, widget::button};
 
 use crate::ui::{
     components::navigation_bar::Message,
-    theme::Theme,
+    theme::{Theme, catalog},
     widgets::{
         icons::{self, icon},
         menu::{
@@ -14,7 +14,13 @@ use crate::ui::{
 pub fn navigation_bar_menu<'a>(theme: &Theme) -> Element<'a, Message, Theme, Renderer> {
     let dropdown = dropdown_toggle(
         theme,
-        button(icon(icons::MENU)),
+        button(
+            icon(icons::MENU)
+                .size(theme.sizes.font.h2)
+                .color(theme.palette.text),
+        )
+        .padding(Padding::default())
+        .style(catalog::button::clear_icon_button),
         dropdown_menu(
             theme,
             vec![
@@ -31,14 +37,17 @@ pub fn navigation_bar_menu<'a>(theme: &Theme) -> Element<'a, Message, Theme, Ren
                                 Some(Message::SelectedScanDirectoryOption),
                             ),
                         ],
-                    ),
+                    )
+                    .width(220.0)
+                    .offset(12.0),
                 ),
                 dropdown_menu_option(theme, "Edit", None),
                 dropdown_menu_option(theme, "View", None),
                 dropdown_menu_option(theme, "Controls", None),
                 dropdown_menu_option(theme, "Help", None),
             ],
-        ),
+        )
+        .width(Length::Fixed(100.0)),
     );
 
     dropdown.into()

--- a/src/ui/components/navigation_bar/navigation_bar_menu.rs
+++ b/src/ui/components/navigation_bar/navigation_bar_menu.rs
@@ -61,7 +61,11 @@ pub fn file_menu<'a>(theme: &Theme) -> DropdownMenu<'a, Message> {
 pub fn edit_menu<'a>(theme: &Theme) -> DropdownMenu<'a, Message> {
     dropdown_menu(
         theme,
-        vec![dropdown_menu_option(theme, "Manage Tags", None)],
+        vec![dropdown_menu_option(
+            theme,
+            "Manage Tags",
+            Some(Message::SelectedEditMenuManageTagsOption),
+        )],
     )
     .width(160.0)
     .offset(12.0)

--- a/src/ui/components/navigation_bar/navigation_bar_menu.rs
+++ b/src/ui/components/navigation_bar/navigation_bar_menu.rs
@@ -1,4 +1,4 @@
-use iced::{Element, Length, Padding, Renderer, widget::button};
+use iced::{Length, Padding, widget::button};
 
 use crate::ui::{
     components::navigation_bar::Message,
@@ -6,13 +6,14 @@ use crate::ui::{
     widgets::{
         icons::{self, icon},
         menu::{
-            dropdown_menu, dropdown_menu_grouping_option, dropdown_menu_option, dropdown_toggle,
+            DropdownMenu, DropdownMenuToggle, dropdown_menu, dropdown_menu_grouping_option,
+            dropdown_menu_option, dropdown_toggle,
         },
     },
 };
 
-pub fn navigation_bar_menu<'a>(theme: &Theme) -> Element<'a, Message, Theme, Renderer> {
-    let dropdown = dropdown_toggle(
+pub fn main_menu_dropdown<'a>(theme: &Theme) -> DropdownMenuToggle<'a, Message> {
+    dropdown_toggle(
         theme,
         button(
             icon(icons::MENU)
@@ -21,34 +22,47 @@ pub fn navigation_bar_menu<'a>(theme: &Theme) -> Element<'a, Message, Theme, Ren
         )
         .padding(Padding::default())
         .style(catalog::button::clear_icon_button),
-        dropdown_menu(
-            theme,
-            vec![
-                dropdown_menu_grouping_option(
-                    theme,
-                    "File",
-                    dropdown_menu(
-                        theme,
-                        vec![
-                            dropdown_menu_option(theme, "Add new files to library", None),
-                            dropdown_menu_option(
-                                theme,
-                                "Scan folder for new files",
-                                Some(Message::SelectedScanDirectoryOption),
-                            ),
-                        ],
-                    )
-                    .width(220.0)
-                    .offset(12.0),
-                ),
-                dropdown_menu_option(theme, "Edit", None),
-                dropdown_menu_option(theme, "View", None),
-                dropdown_menu_option(theme, "Controls", None),
-                dropdown_menu_option(theme, "Help", None),
-            ],
-        )
-        .width(Length::Fixed(100.0)),
-    );
+        main_menu(theme),
+    )
+}
 
-    dropdown.into()
+pub fn main_menu<'a>(theme: &Theme) -> DropdownMenu<'a, Message> {
+    dropdown_menu(
+        theme,
+        vec![
+            dropdown_menu_grouping_option(theme, "File", file_menu(theme)),
+            dropdown_menu_grouping_option(theme, "Edit", edit_menu(theme)),
+            // TODO: Add back these options when they are functional
+            // dropdown_menu_option(theme, "View", None),
+            // dropdown_menu_option(theme, "Controls", None),
+            // dropdown_menu_option(theme, "Help", None),
+        ],
+    )
+    .width(Length::Fixed(100.0))
+}
+
+pub fn file_menu<'a>(theme: &Theme) -> DropdownMenu<'a, Message> {
+    dropdown_menu(
+        theme,
+        vec![
+            // TODO: Add back this option when it is functional
+            // dropdown_menu_option(theme, "Add new files to library", None),
+            dropdown_menu_option(
+                theme,
+                "Scan folder for new files",
+                Some(Message::SelectedScanDirectoryOption),
+            ),
+        ],
+    )
+    .width(220.0)
+    .offset(12.0)
+}
+
+pub fn edit_menu<'a>(theme: &Theme) -> DropdownMenu<'a, Message> {
+    dropdown_menu(
+        theme,
+        vec![dropdown_menu_option(theme, "Manage Tags", None)],
+    )
+    .width(160.0)
+    .offset(12.0)
 }

--- a/src/ui/modals/manage_tags/handler.rs
+++ b/src/ui/modals/manage_tags/handler.rs
@@ -27,6 +27,7 @@ impl ModalController {
             .into_iter()
             .map(|outcome| match outcome {
                 Outcome::Modal(outcome) => modals::Outcome::Modal(outcome),
+                Outcome::Tag(outcome) => modals::Outcome::Tag(outcome),
             })
             .collect();
 

--- a/src/ui/modals/manage_tags/handler.rs
+++ b/src/ui/modals/manage_tags/handler.rs
@@ -1,0 +1,39 @@
+use iced::Task;
+
+use crate::{
+    tag::models::{Tag, TagGroup},
+    ui::modals::{
+        self, AppModal, ModalController,
+        manage_tags::{ManageTagsModal, Message, Outcome},
+    },
+};
+
+impl ModalController {
+    pub fn handle_manage_tags_modal(
+        &mut self,
+        message: Message,
+        tags: &[Tag],
+        tag_groups: &[TagGroup],
+    ) -> (Task<modals::Message>, Vec<modals::Outcome>) {
+        let Some(AppModal::ManageTags(manage_tags_modal)) = self.current_modal.as_mut() else {
+            return (Task::none(), Vec::new());
+        };
+
+        let (task, outcomes) = manage_tags_modal.update(message, tags, tag_groups);
+
+        let modal_task = task.map(modals::Message::ManageTagsModal);
+
+        let outcomes = outcomes
+            .into_iter()
+            .map(|outcome| match outcome {
+                Outcome::Modal(outcome) => modals::Outcome::Modal(outcome),
+            })
+            .collect();
+
+        (modal_task, outcomes)
+    }
+
+    pub fn open_manage_tags_modal(&mut self) {
+        self.current_modal = Some(AppModal::ManageTags(ManageTagsModal::new()));
+    }
+}

--- a/src/ui/modals/manage_tags/mod.rs
+++ b/src/ui/modals/manage_tags/mod.rs
@@ -99,9 +99,7 @@ impl ManageTagsModal {
 
     #[instrument(skip(self), level = "debug")]
     pub fn on_event(&mut self, event: &Event) -> Task<Message> {
-        let task = Task::none();
-
-        task
+        Task::none()
     }
 
     #[instrument(skip_all, level = "debug")]

--- a/src/ui/modals/manage_tags/mod.rs
+++ b/src/ui/modals/manage_tags/mod.rs
@@ -1,0 +1,78 @@
+use iced::{
+    Element, Length, Padding, Renderer, Task,
+    widget::{Space, column, container},
+};
+use tracing::instrument;
+
+use crate::{
+    event::Event,
+    outcome::ModalOutcome,
+    tag::models::{Tag, TagGroup},
+    ui::theme::{Theme, catalog},
+};
+
+pub mod handler;
+
+#[derive(Default)]
+pub struct ManageTagsModal {}
+
+#[derive(Debug, Clone)]
+pub enum Message {
+    Close,
+}
+
+pub enum Outcome {
+    Modal(ModalOutcome),
+}
+
+impl ManageTagsModal {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    #[instrument(
+        skip(self, tags, tag_groups)
+        fields( tags_len = tags.len(), tag_groups_len = tag_groups.len()),
+        level = "debug"
+    )]
+    pub fn update(
+        &mut self,
+        message: Message,
+        tags: &[Tag],
+        tag_groups: &[TagGroup],
+    ) -> (Task<Message>, Vec<Outcome>) {
+        let task = Task::none();
+        let mut outcomes = Vec::new();
+
+        match message {
+            Message::Close => outcomes.push(Outcome::Modal(ModalOutcome::CloseModal)),
+        }
+
+        (task, outcomes)
+    }
+
+    #[instrument(skip(self), level = "debug")]
+    pub fn on_event(&mut self, event: &Event) -> Task<Message> {
+        let task = Task::none();
+
+        task
+    }
+
+    #[instrument(skip_all, level = "debug")]
+    pub fn view<'a>(
+        &self,
+        theme: &Theme,
+        tags: &'a [Tag],
+        tag_groups: &'a [TagGroup],
+    ) -> Element<'a, Message, Theme, Renderer> {
+        let width = 1000.0;
+
+        container(Space::new())
+            .width(width)
+            .height(Length::Shrink)
+            // Offsets inner containers so they don't overlap modal container border.
+            .padding(Padding::from(1.0))
+            .style(catalog::container::modal)
+            .into()
+    }
+}

--- a/src/ui/modals/manage_tags/mod.rs
+++ b/src/ui/modals/manage_tags/mod.rs
@@ -9,12 +9,14 @@ use crate::{
     outcome::ModalOutcome,
     tag::models::{Tag, TagGroup},
     ui::{
+        modals::manage_tags::widgets::header,
         theme::{Theme, catalog},
         widgets::separator::{horizontal_separator, vertical_separator},
     },
 };
 
 pub mod handler;
+pub mod widgets;
 
 #[derive(Default)]
 pub struct ManageTagsModal {}
@@ -69,7 +71,7 @@ impl ManageTagsModal {
         tag_groups: &'a [TagGroup],
     ) -> Element<'a, Message, Theme, Renderer> {
         container(column![
-            container(text("Header")).height(64.0).width(Length::Fill),
+            header(theme, tag_groups),
             vertical_separator(),
             row![
                 column![
@@ -80,7 +82,8 @@ impl ManageTagsModal {
                     container(text("Tag groups input"))
                         .height(80.0)
                         .width(Length::Fill)
-                ],
+                ]
+                .width(Length::FillPortion(1)),
                 horizontal_separator(),
                 column![
                     container(text("Tags group tags list"))
@@ -91,14 +94,15 @@ impl ManageTagsModal {
                         .height(80.0)
                         .width(Length::Fill)
                 ]
+                .width(Length::FillPortion(2))
             ]
             .height(Length::Fill)
             .width(Length::Fill),
             vertical_separator(),
-            container(text("Footer")).height(50.0).width(Length::Fill)
+            container(text("Footer")).height(84.0).width(Length::Fill)
         ])
-        .width(670.0)
-        .height(500.0)
+        .width(890.0)
+        .height(660.0)
         // Offsets inner containers so they don't overlap modal container border.
         .padding(Padding::from(1.0))
         .style(catalog::container::modal)

--- a/src/ui/modals/manage_tags/mod.rs
+++ b/src/ui/modals/manage_tags/mod.rs
@@ -7,9 +7,9 @@ use tracing::instrument;
 use crate::{
     event::Event,
     outcome::ModalOutcome,
-    tag::models::{Tag, TagGroup},
+    tag::models::{Tag, TagGroup, TagGroupId},
     ui::{
-        modals::manage_tags::widgets::header,
+        modals::manage_tags::widgets::{header, tag_group_pane, tag_group_tags_pane},
         theme::{Theme, catalog},
         widgets::separator::{horizontal_separator, vertical_separator},
     },
@@ -19,11 +19,14 @@ pub mod handler;
 pub mod widgets;
 
 #[derive(Default)]
-pub struct ManageTagsModal {}
+pub struct ManageTagsModal {
+    selected_tag_group_id: Option<TagGroupId>,
+}
 
 #[derive(Debug, Clone)]
 pub enum Message {
     Close,
+    SelectTagGroup(TagGroupId),
 }
 
 pub enum Outcome {
@@ -32,7 +35,9 @@ pub enum Outcome {
 
 impl ManageTagsModal {
     pub fn new() -> Self {
-        Self {}
+        Self {
+            selected_tag_group_id: None,
+        }
     }
 
     #[instrument(
@@ -51,6 +56,9 @@ impl ManageTagsModal {
 
         match message {
             Message::Close => outcomes.push(Outcome::Modal(ModalOutcome::CloseModal)),
+            Message::SelectTagGroup(tag_group_id) => {
+                self.selected_tag_group_id = Some(tag_group_id);
+            }
         }
 
         (task, outcomes)
@@ -70,31 +78,25 @@ impl ManageTagsModal {
         tags: &'a [Tag],
         tag_groups: &'a [TagGroup],
     ) -> Element<'a, Message, Theme, Renderer> {
+        let tag_group = self
+            .selected_tag_group_id
+            .and_then(|selected_tag_group_id| {
+                tag_groups
+                    .iter()
+                    .find(|tag_group| tag_group.id == selected_tag_group_id)
+            });
+        let tag_group_tags = tags.iter().filter(|&tag| {
+            self.selected_tag_group_id
+                .is_some_and(|selected_tag_group_id| tag.tag_group_id == selected_tag_group_id)
+        });
+
         container(column![
             header(theme, tag_groups),
             vertical_separator(),
             row![
-                column![
-                    container(text("Tag groups list"))
-                        .height(Length::Fill)
-                        .width(Length::Fill),
-                    vertical_separator(),
-                    container(text("Tag groups input"))
-                        .height(80.0)
-                        .width(Length::Fill)
-                ]
-                .width(Length::FillPortion(1)),
+                tag_group_pane(theme, tag_groups),
                 horizontal_separator(),
-                column![
-                    container(text("Tags group tags list"))
-                        .height(Length::Fill)
-                        .width(Length::Fill),
-                    vertical_separator(),
-                    container(text("Tag groups tags input"))
-                        .height(80.0)
-                        .width(Length::Fill)
-                ]
-                .width(Length::FillPortion(2))
+                tag_group_tags_pane(theme, tag_group, tag_group_tags)
             ]
             .height(Length::Fill)
             .width(Length::Fill),

--- a/src/ui/modals/manage_tags/mod.rs
+++ b/src/ui/modals/manage_tags/mod.rs
@@ -1,12 +1,12 @@
 use iced::{
     Element, Length, Padding, Renderer, Task,
-    widget::{column, container, row, text},
+    widget::{column, container, row},
 };
 use tracing::instrument;
 
 use crate::{
     event::Event,
-    outcome::ModalOutcome,
+    outcome::{ModalOutcome, TagOutcome},
     tag::models::{Tag, TagGroup, TagGroupId},
     ui::{
         modals::manage_tags::widgets::{footer, header, tag_group_pane, tag_group_tags_pane},
@@ -21,22 +21,31 @@ pub mod widgets;
 #[derive(Default)]
 pub struct ManageTagsModal {
     selected_tag_group_id: Option<TagGroupId>,
+    new_tag_group_name_input_text: String,
+    new_tag_name_input_text: String,
 }
 
 #[derive(Debug, Clone)]
 pub enum Message {
     Close,
     SelectTagGroup(TagGroupId),
+    NewTagGroupNameInputTextChanged(String),
+    AddNewTagGroup,
+    NewTagNameInputTextChanged(String),
+    AddNewTag,
 }
 
 pub enum Outcome {
     Modal(ModalOutcome),
+    Tag(TagOutcome),
 }
 
 impl ManageTagsModal {
     pub fn new() -> Self {
         Self {
             selected_tag_group_id: None,
+            new_tag_group_name_input_text: String::new(),
+            new_tag_name_input_text: String::new(),
         }
     }
 
@@ -58,6 +67,30 @@ impl ManageTagsModal {
             Message::Close => outcomes.push(Outcome::Modal(ModalOutcome::CloseModal)),
             Message::SelectTagGroup(tag_group_id) => {
                 self.selected_tag_group_id = Some(tag_group_id);
+            }
+            Message::NewTagGroupNameInputTextChanged(new_tag_group_name_input_text) => {
+                self.new_tag_group_name_input_text = new_tag_group_name_input_text;
+            }
+            Message::NewTagNameInputTextChanged(new_tag_name_input_text) => {
+                self.new_tag_name_input_text = new_tag_name_input_text;
+            }
+            Message::AddNewTag if let Some(selected_tag_group_id) = self.selected_tag_group_id => {
+                outcomes.push(Outcome::Tag(TagOutcome::AddNewTag(
+                    selected_tag_group_id,
+                    self.new_tag_name_input_text.clone(),
+                )));
+
+                self.new_tag_name_input_text.clear();
+            }
+            Message::AddNewTagGroup => {
+                outcomes.push(Outcome::Tag(TagOutcome::AddNewTagGroup(
+                    self.new_tag_group_name_input_text.clone(),
+                )));
+
+                self.new_tag_group_name_input_text.clear();
+            }
+            Message::AddNewTag => {
+                // Not reachable
             }
         }
 
@@ -94,9 +127,14 @@ impl ManageTagsModal {
             header(theme, tag_groups),
             vertical_separator(),
             row![
-                tag_group_pane(theme, tag_groups),
+                tag_group_pane(theme, tag_groups, &self.new_tag_group_name_input_text),
                 horizontal_separator(),
-                tag_group_tags_pane(theme, tag_group, tag_group_tags)
+                tag_group_tags_pane(
+                    theme,
+                    tag_group,
+                    tag_group_tags,
+                    &self.new_tag_name_input_text
+                )
             ]
             .height(Length::Fill)
             .width(Length::Fill),

--- a/src/ui/modals/manage_tags/mod.rs
+++ b/src/ui/modals/manage_tags/mod.rs
@@ -1,6 +1,6 @@
 use iced::{
     Element, Length, Padding, Renderer, Task,
-    widget::{Space, column, container},
+    widget::{column, container, row, text},
 };
 use tracing::instrument;
 
@@ -8,7 +8,10 @@ use crate::{
     event::Event,
     outcome::ModalOutcome,
     tag::models::{Tag, TagGroup},
-    ui::theme::{Theme, catalog},
+    ui::{
+        theme::{Theme, catalog},
+        widgets::separator::{horizontal_separator, vertical_separator},
+    },
 };
 
 pub mod handler;
@@ -65,14 +68,40 @@ impl ManageTagsModal {
         tags: &'a [Tag],
         tag_groups: &'a [TagGroup],
     ) -> Element<'a, Message, Theme, Renderer> {
-        let width = 1000.0;
-
-        container(Space::new())
-            .width(width)
-            .height(Length::Shrink)
-            // Offsets inner containers so they don't overlap modal container border.
-            .padding(Padding::from(1.0))
-            .style(catalog::container::modal)
-            .into()
+        container(column![
+            container(text("Header")).height(64.0).width(Length::Fill),
+            vertical_separator(),
+            row![
+                column![
+                    container(text("Tag groups list"))
+                        .height(Length::Fill)
+                        .width(Length::Fill),
+                    vertical_separator(),
+                    container(text("Tag groups input"))
+                        .height(80.0)
+                        .width(Length::Fill)
+                ],
+                horizontal_separator(),
+                column![
+                    container(text("Tags group tags list"))
+                        .height(Length::Fill)
+                        .width(Length::Fill),
+                    vertical_separator(),
+                    container(text("Tag groups tags input"))
+                        .height(80.0)
+                        .width(Length::Fill)
+                ]
+            ]
+            .height(Length::Fill)
+            .width(Length::Fill),
+            vertical_separator(),
+            container(text("Footer")).height(50.0).width(Length::Fill)
+        ])
+        .width(670.0)
+        .height(500.0)
+        // Offsets inner containers so they don't overlap modal container border.
+        .padding(Padding::from(1.0))
+        .style(catalog::container::modal)
+        .into()
     }
 }

--- a/src/ui/modals/manage_tags/mod.rs
+++ b/src/ui/modals/manage_tags/mod.rs
@@ -7,7 +7,7 @@ use tracing::instrument;
 use crate::{
     event::Event,
     outcome::{ModalOutcome, TagOutcome},
-    tag::models::{Tag, TagGroup, TagGroupId},
+    tag::models::{Tag, TagGroup, TagGroupId, TagId},
     ui::{
         modals::manage_tags::widgets::{footer, header, tag_group_pane, tag_group_tags_pane},
         theme::{Theme, catalog},
@@ -31,8 +31,10 @@ pub enum Message {
     SelectTagGroup(TagGroupId),
     NewTagGroupNameInputTextChanged(String),
     AddNewTagGroup,
+    RemoveTagGroup(TagGroupId),
     NewTagNameInputTextChanged(String),
     AddNewTag,
+    RemoveTag(TagId),
 }
 
 pub enum Outcome {
@@ -91,6 +93,13 @@ impl ManageTagsModal {
             }
             Message::AddNewTag => {
                 // Not reachable
+            }
+
+            Message::RemoveTagGroup(tag_group_id) => {
+                outcomes.push(Outcome::Tag(TagOutcome::RemoveTagGroup(tag_group_id)));
+            }
+            Message::RemoveTag(tag_id) => {
+                outcomes.push(Outcome::Tag(TagOutcome::RemoveTag(tag_id)));
             }
         }
 

--- a/src/ui/modals/manage_tags/mod.rs
+++ b/src/ui/modals/manage_tags/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     outcome::ModalOutcome,
     tag::models::{Tag, TagGroup, TagGroupId},
     ui::{
-        modals::manage_tags::widgets::{header, tag_group_pane, tag_group_tags_pane},
+        modals::manage_tags::widgets::{footer, header, tag_group_pane, tag_group_tags_pane},
         theme::{Theme, catalog},
         widgets::separator::{horizontal_separator, vertical_separator},
     },
@@ -101,7 +101,7 @@ impl ManageTagsModal {
             .height(Length::Fill)
             .width(Length::Fill),
             vertical_separator(),
-            container(text("Footer")).height(84.0).width(Length::Fill)
+            footer(theme)
         ])
         .width(890.0)
         .height(660.0)

--- a/src/ui/modals/manage_tags/widgets.rs
+++ b/src/ui/modals/manage_tags/widgets.rs
@@ -47,11 +47,12 @@ pub fn header<'a>(theme: &Theme, tag_groups: &[TagGroup]) -> Element<'a, Message
 pub fn tag_group_pane<'a>(
     theme: &Theme,
     tag_groups: &'a [TagGroup],
+    new_tag_group_name: &str,
 ) -> Element<'a, Message, Theme, Renderer> {
     column![
         tag_group_list(theme, tag_groups),
         vertical_separator(),
-        tag_group_input(theme)
+        tag_group_input(theme, new_tag_group_name)
     ]
     .height(Length::Fill)
     .width(Length::FillPortion(1))
@@ -86,13 +87,19 @@ pub fn tag_group_list<'a>(
     .into()
 }
 
-pub fn tag_group_input<'a>(theme: &Theme) -> Element<'a, Message, Theme, Renderer> {
+pub fn tag_group_input<'a>(
+    theme: &Theme,
+    new_tag_group_name: &str,
+) -> Element<'a, Message, Theme, Renderer> {
     container(
         column![
             text("New group")
                 .size(theme.sizes.font.small)
                 .color(theme.palette.text_muted),
-            text_input("Group name", "").padding(Padding::from(theme.sizes.space.lg))
+            text_input("Group name", new_tag_group_name)
+                .on_input(Message::NewTagGroupNameInputTextChanged)
+                .on_submit(Message::AddNewTagGroup)
+                .padding(Padding::from(theme.sizes.space.lg))
         ]
         .spacing(theme.sizes.space.md),
     )
@@ -106,6 +113,7 @@ pub fn tag_group_tags_pane<'a>(
     theme: &Theme,
     tag_group: Option<&'a TagGroup>,
     tag_group_tags: impl Iterator<Item = &'a Tag>,
+    new_tag_name: &str,
 ) -> Element<'a, Message, Theme, Renderer> {
     let Some(tag_group) = tag_group else {
         return center(
@@ -126,7 +134,7 @@ pub fn tag_group_tags_pane<'a>(
     column![
         tag_group_tags_list(theme, tag_group, tag_group_tags),
         vertical_separator(),
-        tag_groups_tags_input(theme)
+        tag_groups_tags_input(theme, new_tag_name)
     ]
     .width(Length::FillPortion(2))
     .padding(Padding::from([theme.sizes.space.xl, theme.sizes.space.xxl]))
@@ -163,13 +171,19 @@ pub fn tag_group_tags_list<'a>(
     .into()
 }
 
-pub fn tag_groups_tags_input<'a>(theme: &Theme) -> Element<'a, Message, Theme, Renderer> {
+pub fn tag_groups_tags_input<'a>(
+    theme: &Theme,
+    new_tag_name: &str,
+) -> Element<'a, Message, Theme, Renderer> {
     container(
         column![
             text("New tag")
                 .size(theme.sizes.font.small)
                 .color(theme.palette.text_muted),
-            text_input("Tag name", "").padding(Padding::from(theme.sizes.space.lg))
+            text_input("Tag name", new_tag_name)
+                .on_input(Message::NewTagNameInputTextChanged)
+                .on_submit(Message::AddNewTag)
+                .padding(Padding::from(theme.sizes.space.lg))
         ]
         .spacing(theme.sizes.space.md),
     )

--- a/src/ui/modals/manage_tags/widgets.rs
+++ b/src/ui/modals/manage_tags/widgets.rs
@@ -1,14 +1,18 @@
 use iced::{
-    Element, Length, Padding, Renderer,
-    widget::{Space, button, column, container, row, text},
+    Element, Length, Padding, Renderer, alignment,
+    widget::{Space, button, center, column, container, row, scrollable, text},
 };
+use iced_palace::widget::ellipsized_text;
 
 use crate::{
-    tag::models::TagGroup,
+    tag::models::{Tag, TagGroup},
     ui::{
         modals::manage_tags::Message,
         theme::{Theme, catalog},
-        widgets::icons::{self, icon},
+        widgets::{
+            icons::{self, icon},
+            separator::vertical_separator,
+        },
     },
 };
 
@@ -37,5 +41,117 @@ pub fn header<'a>(theme: &Theme, tag_groups: &[TagGroup]) -> Element<'a, Message
     .width(Length::Fill)
     .padding(Padding::from([theme.sizes.space.xl, theme.sizes.space.xxl]))
     .style(catalog::container::modal_header)
+    .into()
+}
+
+pub fn tag_group_pane<'a>(
+    theme: &Theme,
+    tag_groups: &'a [TagGroup],
+) -> Element<'a, Message, Theme, Renderer> {
+    column![
+        tag_group_list(theme, tag_groups),
+        vertical_separator(),
+        tag_group_input(theme)
+    ]
+    .height(Length::Fill)
+    .width(Length::FillPortion(1))
+    .into()
+}
+
+pub fn tag_group_list<'a>(
+    theme: &Theme,
+    tag_groups: &'a [TagGroup],
+) -> Element<'a, Message, Theme, Renderer> {
+    let tag_group_list_elements: Vec<Element<'a, Message, Theme, Renderer>> = tag_groups
+        .iter()
+        .map(|tag_group| {
+            button(ellipsized_text(&tag_group.name))
+                .width(Length::Fill)
+                .padding(Padding::from(theme.sizes.space.lg))
+                .on_press(Message::SelectTagGroup(tag_group.id))
+                .into()
+        })
+        .collect();
+
+    column![
+        text("TAG GROUPS")
+            .size(theme.sizes.font.body)
+            .color(theme.palette.text_muted),
+        scrollable(column(tag_group_list_elements))
+    ]
+    .spacing(theme.sizes.space.lg)
+    .height(Length::Fill)
+    .width(Length::Fill)
+    .padding(Padding::from([theme.sizes.space.xl, theme.sizes.space.xxl]))
+    .into()
+}
+
+pub fn tag_group_input<'a>(theme: &Theme) -> Element<'a, Message, Theme, Renderer> {
+    container(text("Tag groups input"))
+        .height(100.0)
+        .width(Length::Fill)
+        .into()
+}
+
+pub fn tag_group_tags_pane<'a>(
+    theme: &Theme,
+    tag_group: Option<&'a TagGroup>,
+    tag_group_tags: impl Iterator<Item = &'a Tag>,
+) -> Element<'a, Message, Theme, Renderer> {
+    let Some(tag_group) = tag_group else {
+        return center(
+            column![
+                text("No tags to display").size(theme.sizes.font.h2),
+                text("Create or select a tag group to manage its tags")
+                    .size(theme.sizes.font.small)
+                    .color(theme.palette.text_muted)
+            ]
+            .spacing(theme.sizes.space.lg)
+            .align_x(alignment::Horizontal::Center),
+        )
+        .height(Length::Fill)
+        .width(Length::FillPortion(2))
+        .into();
+    };
+
+    column![
+        tag_group_tags_list(theme, tag_group, tag_group_tags),
+        vertical_separator(),
+        container(text("Tag groups tags input"))
+            .height(100.0)
+            .width(Length::Fill)
+    ]
+    .width(Length::FillPortion(2))
+    .padding(Padding::from([theme.sizes.space.xl, theme.sizes.space.xxl]))
+    .into()
+}
+
+pub fn tag_group_tags_list<'a>(
+    theme: &Theme,
+    tag_group: &'a TagGroup,
+    tag_group_tags: impl Iterator<Item = &'a Tag>,
+) -> Element<'a, Message, Theme, Renderer> {
+    let tag_group_tags_elements: Vec<Element<'a, Message, Theme, Renderer>> = tag_group_tags
+        .map(|tag| button(text(&tag.name)).into())
+        .collect();
+
+    let list_title = &tag_group.name;
+    let list_subtitle = format!("{} / 36 tags", tag_group_tags_elements.len());
+
+    column![
+        column![
+            text(list_title),
+            text(list_subtitle)
+                .size(theme.sizes.font.small)
+                .color(theme.palette.text_muted)
+        ]
+        .spacing(theme.sizes.space.md),
+        row(tag_group_tags_elements)
+            .spacing(theme.sizes.space.md)
+            .wrap()
+    ]
+    .spacing(theme.sizes.space.lg)
+    .height(Length::Fill)
+    .width(Length::Fill)
     .into()
 }

--- a/src/ui/modals/manage_tags/widgets.rs
+++ b/src/ui/modals/manage_tags/widgets.rs
@@ -1,6 +1,6 @@
 use iced::{
     Element, Length, Padding, Renderer, alignment,
-    widget::{Space, button, center, column, container, row, scrollable, text},
+    widget::{Space, button, center, column, container, right, row, scrollable, text, text_input},
 };
 use iced_palace::widget::ellipsized_text;
 
@@ -87,10 +87,19 @@ pub fn tag_group_list<'a>(
 }
 
 pub fn tag_group_input<'a>(theme: &Theme) -> Element<'a, Message, Theme, Renderer> {
-    container(text("Tag groups input"))
-        .height(100.0)
-        .width(Length::Fill)
-        .into()
+    container(
+        column![
+            text("New group")
+                .size(theme.sizes.font.small)
+                .color(theme.palette.text_muted),
+            text_input("Group name", "").padding(Padding::from(theme.sizes.space.lg))
+        ]
+        .spacing(theme.sizes.space.md),
+    )
+    .height(104.0)
+    .width(Length::Fill)
+    .padding(Padding::from([theme.sizes.space.xl, theme.sizes.space.xxl]))
+    .into()
 }
 
 pub fn tag_group_tags_pane<'a>(
@@ -117,9 +126,7 @@ pub fn tag_group_tags_pane<'a>(
     column![
         tag_group_tags_list(theme, tag_group, tag_group_tags),
         vertical_separator(),
-        container(text("Tag groups tags input"))
-            .height(100.0)
-            .width(Length::Fill)
+        tag_groups_tags_input(theme)
     ]
     .width(Length::FillPortion(2))
     .padding(Padding::from([theme.sizes.space.xl, theme.sizes.space.xxl]))
@@ -153,5 +160,39 @@ pub fn tag_group_tags_list<'a>(
     .spacing(theme.sizes.space.lg)
     .height(Length::Fill)
     .width(Length::Fill)
+    .into()
+}
+
+pub fn tag_groups_tags_input<'a>(theme: &Theme) -> Element<'a, Message, Theme, Renderer> {
+    container(
+        column![
+            text("New tag")
+                .size(theme.sizes.font.small)
+                .color(theme.palette.text_muted),
+            text_input("Tag name", "").padding(Padding::from(theme.sizes.space.lg))
+        ]
+        .spacing(theme.sizes.space.md),
+    )
+    .padding(Padding::default().top(theme.sizes.space.xl))
+    .height(88.0)
+    .width(Length::Fill)
+    .into()
+}
+
+pub fn footer<'a>(theme: &Theme) -> Element<'a, Message, Theme, Renderer> {
+    right(
+        button(text("Done"))
+            .on_press(Message::Close)
+            .padding(Padding::from([
+                theme.sizes.space.xl,
+                theme.sizes.space.xxxl,
+            ]))
+            .style(catalog::button::modal_footer_button),
+    )
+    .align_y(alignment::Vertical::Center)
+    .height(84.0)
+    .width(Length::Fill)
+    .padding(Padding::from([theme.sizes.space.xl, theme.sizes.space.xxl]))
+    .style(catalog::container::modal_footer)
     .into()
 }

--- a/src/ui/modals/manage_tags/widgets.rs
+++ b/src/ui/modals/manage_tags/widgets.rs
@@ -67,8 +67,9 @@ pub fn tag_group_list<'a>(
         .iter()
         .map(|tag_group| {
             button(row![
-                ellipsized_text(&tag_group.name),
-                Space::new().width(Length::Fill),
+                ellipsized_text(&tag_group.name)
+                    .wrapping(text::Wrapping::None)
+                    .width(Length::Fill),
                 button(icon(icons::CLOSE).size(theme.sizes.font.caption))
                     .on_press(Message::RemoveTagGroup(tag_group.id))
                     .padding(Padding::from([theme.sizes.space.sm, theme.sizes.space.md]))
@@ -158,7 +159,8 @@ pub fn tag_group_tags_list<'a>(
         .map(|tag| {
             button(
                 row![
-                    text(&tag.name),
+                    container(ellipsized_text(&tag.name).wrapping(text::Wrapping::None))
+                        .max_width(500),
                     button(icon(icons::CLOSE).size(theme.sizes.font.caption))
                         .on_press(Message::RemoveTag(tag.id))
                         .padding(Padding::from([theme.sizes.space.sm, theme.sizes.space.md]))
@@ -182,9 +184,11 @@ pub fn tag_group_tags_list<'a>(
                 .color(theme.palette.text_muted)
         ]
         .spacing(theme.sizes.space.md),
-        row(tag_group_tags_elements)
-            .spacing(theme.sizes.space.md)
-            .wrap()
+        scrollable(
+            row(tag_group_tags_elements)
+                .spacing(theme.sizes.space.md)
+                .wrap()
+        )
     ]
     .spacing(theme.sizes.space.lg)
     .height(Length::Fill)

--- a/src/ui/modals/manage_tags/widgets.rs
+++ b/src/ui/modals/manage_tags/widgets.rs
@@ -66,11 +66,19 @@ pub fn tag_group_list<'a>(
     let tag_group_list_elements: Vec<Element<'a, Message, Theme, Renderer>> = tag_groups
         .iter()
         .map(|tag_group| {
-            button(ellipsized_text(&tag_group.name))
-                .width(Length::Fill)
-                .padding(Padding::from(theme.sizes.space.lg))
-                .on_press(Message::SelectTagGroup(tag_group.id))
-                .into()
+            button(row![
+                ellipsized_text(&tag_group.name),
+                Space::new().width(Length::Fill),
+                button(icon(icons::CLOSE).size(theme.sizes.font.caption))
+                    .on_press(Message::RemoveTagGroup(tag_group.id))
+                    .padding(Padding::from([theme.sizes.space.sm, theme.sizes.space.md]))
+                    .style(catalog::button::clear_icon_button)
+            ])
+            .width(Length::Fill)
+            .padding(Padding::from(theme.sizes.space.lg))
+            .on_press(Message::SelectTagGroup(tag_group.id))
+            .style(catalog::button::menu_option)
+            .into()
         })
         .collect();
 
@@ -147,7 +155,20 @@ pub fn tag_group_tags_list<'a>(
     tag_group_tags: impl Iterator<Item = &'a Tag>,
 ) -> Element<'a, Message, Theme, Renderer> {
     let tag_group_tags_elements: Vec<Element<'a, Message, Theme, Renderer>> = tag_group_tags
-        .map(|tag| button(text(&tag.name)).into())
+        .map(|tag| {
+            button(
+                row![
+                    text(&tag.name),
+                    button(icon(icons::CLOSE).size(theme.sizes.font.caption))
+                        .on_press(Message::RemoveTag(tag.id))
+                        .padding(Padding::from([theme.sizes.space.sm, theme.sizes.space.md]))
+                        .style(catalog::button::clear_icon_button)
+                ]
+                .spacing(theme.sizes.space.md),
+            )
+            .padding(Padding::from(theme.sizes.space.md))
+            .into()
+        })
         .collect();
 
     let list_title = &tag_group.name;

--- a/src/ui/modals/manage_tags/widgets.rs
+++ b/src/ui/modals/manage_tags/widgets.rs
@@ -1,0 +1,41 @@
+use iced::{
+    Element, Length, Padding, Renderer,
+    widget::{Space, button, column, container, row, text},
+};
+
+use crate::{
+    tag::models::TagGroup,
+    ui::{
+        modals::manage_tags::Message,
+        theme::{Theme, catalog},
+        widgets::icons::{self, icon},
+    },
+};
+
+pub fn header<'a>(theme: &Theme, tag_groups: &[TagGroup]) -> Element<'a, Message, Theme, Renderer> {
+    let title = "Manage tags";
+    let subtitle = match tag_groups.len() {
+        0 => "No tag groups".to_owned(),
+        1 => "1 tag group".to_owned(),
+        tag_groups_len => format!("{tag_groups_len} tag groups"),
+    };
+
+    container(row![
+        column![
+            text(title).size(theme.sizes.font.h2),
+            text(subtitle)
+                .size(theme.sizes.font.small)
+                .color(theme.palette.text_muted),
+        ]
+        .spacing(theme.sizes.space.lg),
+        Space::new().width(Length::Fill),
+        button(icon(icons::CLOSE))
+            .on_press(Message::Close)
+            .style(catalog::button::clear_icon_button)
+    ])
+    .height(84.0)
+    .width(Length::Fill)
+    .padding(Padding::from([theme.sizes.space.xl, theme.sizes.space.xxl]))
+    .style(catalog::container::modal_header)
+    .into()
+}

--- a/src/ui/modals/mod.rs
+++ b/src/ui/modals/mod.rs
@@ -12,14 +12,18 @@ use crate::{
         models::{Tag, TagGroup},
     },
     track::models::{Track, TrackId},
-    ui::{modals::tag_tracks::TagTracksModal, theme::Theme},
+    ui::{
+        modals::{manage_tags::ManageTagsModal, tag_tracks::TagTracksModal},
+        theme::Theme,
+    },
 };
 
 pub mod handler;
+pub mod manage_tags;
 pub mod tag_tracks;
 
 pub enum AppModal {
-    ManageTags(()),
+    ManageTags(ManageTagsModal),
     TagTracks(TagTracksModal),
 }
 
@@ -35,7 +39,7 @@ pub enum Message {
     OpenManageTagsModal,
     OpenTagTracksModal(Vec<TrackId>),
     CloseModal,
-    // ManageTagsModal(manage_tags::Message)
+    ManageTagsModal(manage_tags::Message),
     TagTracksModal(tag_tracks::Message),
 }
 
@@ -64,7 +68,7 @@ impl ModalController {
 
         match message {
             Message::OpenManageTagsModal => {
-                self.current_modal = Some(AppModal::ManageTags(()));
+                self.open_manage_tags_modal();
             }
             Message::OpenTagTracksModal(track_tagging_queue) => {
                 self.open_tag_tracks_modal(track_tagging_queue);
@@ -84,9 +88,9 @@ impl ModalController {
                 );
             }
             Message::Keyboard(_) => {}
-            // Message::ManageTagsModal(message) => {
-            //     self.handle_manage_tags_modal(message);
-            // }
+            Message::ManageTagsModal(message) => {
+                (task, outcomes) = self.handle_manage_tags_modal(message, tags, tag_groups);
+            }
             Message::TagTracksModal(message) => {
                 (task, outcomes) = self.handle_tag_tracks_modal(
                     message,
@@ -110,12 +114,14 @@ impl ModalController {
         let mut task = Task::none();
 
         let Some(current_modal) = self.current_modal.as_mut() else {
-            return Task::none();
+            return task;
         };
 
         match current_modal {
-            AppModal::ManageTags(_manage_tags_modal) => {
-                // task = manage_tags_modal.on_event(event);
+            AppModal::ManageTags(manage_tags_modal) => {
+                task = manage_tags_modal
+                    .on_event(event)
+                    .map(Message::ManageTagsModal);
             }
             AppModal::TagTracks(tag_tracks_modal) => {
                 task = tag_tracks_modal
@@ -136,22 +142,18 @@ impl ModalController {
         tag_groups: &'a [TagGroup],
         track_tag_index: &'a TrackTagIndex,
     ) -> Option<Element<'a, Message, Theme, Renderer>> {
-        let mut modal = None;
-
         match self.current_modal.as_ref()? {
-            AppModal::ManageTags(_manage_tags_modal) => {
-                //modal = manage_tags_modal.view(theme)
-            }
-            AppModal::TagTracks(tag_tracks_modal) => {
-                modal = Some(
-                    tag_tracks_modal
-                        .view(theme, tracks, tags, tag_groups, track_tag_index)
-                        .map(Message::TagTracksModal),
-                );
-            }
+            AppModal::ManageTags(manage_tags_modal) => Some(
+                manage_tags_modal
+                    .view(theme, tags, tag_groups)
+                    .map(Message::ManageTagsModal),
+            ),
+            AppModal::TagTracks(tag_tracks_modal) => Some(
+                tag_tracks_modal
+                    .view(theme, tracks, tags, tag_groups, track_tag_index)
+                    .map(Message::TagTracksModal),
+            ),
         }
-
-        modal
     }
 
     pub fn close_modal(&mut self) -> Task<app::Message> {

--- a/src/ui/modals/tag_tracks/mod.rs
+++ b/src/ui/modals/tag_tracks/mod.rs
@@ -535,7 +535,7 @@ impl TagTracksModal {
                 // container(text("Keyboard controls"))
                 //     .height(140.0)
                 //     .width(Length::Fill),
-                vertical_separator(),
+                // vertical_separator(),
                 footer(
                     theme,
                     &self.track_tagging_queue,

--- a/src/ui/modals/tag_tracks/widgets.rs
+++ b/src/ui/modals/tag_tracks/widgets.rs
@@ -273,5 +273,6 @@ pub fn footer<'a>(
         theme.sizes.space.xl,
         theme.sizes.space.xxxxl,
     ]))
+    .style(catalog::container::modal_footer)
     .into()
 }

--- a/src/ui/theme/catalog/container.rs
+++ b/src/ui/theme/catalog/container.rs
@@ -84,6 +84,17 @@ pub fn modal_header(theme: &Theme) -> Style {
     }
 }
 
+pub fn modal_footer(theme: &Theme) -> Style {
+    Style {
+        background: Some(theme.palette.surface_raised.into()),
+        border: Border {
+            radius: Radius::default().bottom(theme.sizes.border.radius_lg),
+            ..Border::default()
+        },
+        ..Style::default()
+    }
+}
+
 pub fn separator(theme: &Theme) -> Style {
     Style {
         background: Some(theme.palette.border.into()),

--- a/src/ui/theme/catalog/menu_bar.rs
+++ b/src/ui/theme/catalog/menu_bar.rs
@@ -1,7 +1,7 @@
-use iced::{Background, Border, Color, Shadow, Vector};
+use iced::{Background, Border, Color, Shadow, Vector, border::Radius};
 use iced_aw::style::{
-    menu_bar::{Catalog, Style},
     Status,
+    menu_bar::{Catalog, Style},
 };
 
 use crate::ui::theme::Theme;
@@ -12,7 +12,7 @@ impl Catalog for Theme {
     type Class<'a> = StyleFn<'a>;
 
     fn default<'a>() -> Self::Class<'a> {
-        Box::new(primary)
+        Box::new(default)
     }
 
     fn style(&self, class: &Self::Class<'_>, status: Status) -> Style {
@@ -20,39 +20,34 @@ impl Catalog for Theme {
     }
 }
 
-pub fn primary(theme: &Theme, _status: Status) -> Style {
-    let p = &theme.palette;
-    let s = &theme.sizes;
-
+pub fn default(theme: &Theme, _status: Status) -> Style {
     Style {
-        bar_background: Background::Color(p.surface_raised),
+        bar_background: Color::TRANSPARENT.into(),
         bar_border: Border {
             color: Color::TRANSPARENT,
             width: 0.0,
             radius: 0.0.into(),
         },
-        bar_shadow: Shadow::default(),
 
-        menu_background: Background::Color(p.surface_overlay),
+        menu_background: theme.palette.surface_raised.into(),
         menu_border: Border {
-            color: p.border,
-            width: s.border.width,
-            radius: s.border.radius_md.into(),
+            color: theme.palette.border,
+            width: theme.sizes.border.width,
+            radius: Radius::from(theme.sizes.border.radius_md),
         },
         menu_shadow: Shadow {
-            color: Color {
-                a: 0.35,
-                ..Color::BLACK
-            },
-            offset: Vector::new(0.0, 4.0),
-            blur_radius: 12.0,
+            color: Color::BLACK,
+            blur_radius: theme.sizes.border.radius_md,
+            offset: Vector::new(theme.sizes.space.sm, theme.sizes.space.sm),
         },
 
-        path: Background::Color(p.hover),
+        path: Background::Color(theme.palette.hover),
         path_border: Border {
             color: Color::TRANSPARENT,
             width: 0.0,
-            radius: s.border.radius_sm.into(),
+            radius: theme.sizes.border.radius_sm.into(),
         },
+
+        ..Style::default()
     }
 }

--- a/src/ui/theme/catalog/mod.rs
+++ b/src/ui/theme/catalog/mod.rs
@@ -8,3 +8,4 @@ pub mod slider;
 pub mod split;
 pub mod table;
 pub mod text;
+pub mod text_input;

--- a/src/ui/theme/catalog/text_input.rs
+++ b/src/ui/theme/catalog/text_input.rs
@@ -1,0 +1,36 @@
+use iced::{
+    Background, Border,
+    border::Radius,
+    widget::text_input::{Catalog, Status, Style},
+};
+
+use crate::ui::theme::Theme;
+
+pub type StyleFn<'a> = Box<dyn Fn(&Theme, Status) -> Style + 'a>;
+
+impl Catalog for Theme {
+    type Class<'a> = StyleFn<'a>;
+
+    fn default<'a>() -> Self::Class<'a> {
+        Box::new(default)
+    }
+
+    fn style(&self, class: &Self::Class<'_>, status: Status) -> Style {
+        class(self, status)
+    }
+}
+
+pub fn default(theme: &Theme, status: Status) -> Style {
+    Style {
+        border: Border {
+            color: theme.palette.border,
+            radius: Radius::from(theme.sizes.border.radius_md),
+            width: 1.0,
+        },
+        background: Background::Color(theme.palette.surface_raised),
+        icon: theme.palette.border,
+        placeholder: theme.palette.text_muted,
+        selection: theme.palette.selected,
+        value: theme.palette.text,
+    }
+}

--- a/src/ui/theme/catalog/text_input.rs
+++ b/src/ui/theme/catalog/text_input.rs
@@ -20,7 +20,7 @@ impl Catalog for Theme {
     }
 }
 
-pub fn default(theme: &Theme, status: Status) -> Style {
+pub fn default(theme: &Theme, _status: Status) -> Style {
     Style {
         border: Border {
             color: theme.palette.border,

--- a/src/ui/widgets/menu.rs
+++ b/src/ui/widgets/menu.rs
@@ -1,59 +1,81 @@
 use iced::{
-    Element, Length, Renderer,
-    widget::{Button, button, text},
+    Element, Length, Renderer, alignment,
+    widget::{Button, Space, button, row, text},
 };
 use iced_aw::{Menu, MenuBar, menu::Item};
+use iced_palace::widget::ellipsized_text;
 
-use crate::ui::theme::{Theme, catalog};
+use crate::ui::{
+    theme::{Theme, catalog},
+    widgets::icons::{self, icon},
+};
 
-pub type DropdownMenuToggle<'a, M> = MenuBar<'a, M, Theme, Renderer>;
-pub type DropdownMenuItem<'a, M> = Item<'a, M, Theme, Renderer>;
-pub type DropdownMenu<'a, M> = Menu<'a, M, Theme, Renderer>;
+pub type DropdownMenuToggle<'a, Message> = MenuBar<'a, Message, Theme, Renderer>;
+pub type DropdownMenuItem<'a, Message> = Item<'a, Message, Theme, Renderer>;
+pub type DropdownMenu<'a, Message> = Menu<'a, Message, Theme, Renderer>;
 
-pub fn dropdown_toggle<'a, M>(
+pub fn dropdown_toggle<'a, Message>(
     _theme: &Theme,
-    toggle: impl Into<Element<'a, M, Theme, Renderer>>,
-    menu: DropdownMenu<'a, M>,
-) -> DropdownMenuToggle<'a, M> {
+    toggle: impl Into<Element<'a, Message, Theme, Renderer>>,
+    menu: DropdownMenu<'a, Message>,
+) -> DropdownMenuToggle<'a, Message> {
     MenuBar::new(vec![Item::with_menu(toggle, menu)])
 }
 
-pub fn dropdown_menu<'a, M>(
+pub fn dropdown_menu<'a, Message>(
     _theme: &Theme,
-    items: Vec<DropdownMenuItem<'a, M>>,
-) -> DropdownMenu<'a, M> {
-    Menu::new(items).max_width(220.0).offset(8.0).spacing(2.0)
+    items: Vec<DropdownMenuItem<'a, Message>>,
+) -> DropdownMenu<'a, Message> {
+    Menu::new(items).offset(8.0).spacing(2.0)
 }
 
-pub fn dropdown_menu_item<'a, M>(
+pub fn dropdown_menu_item<'a, Message>(
     _theme: &Theme,
-    content: impl Into<Element<'a, M, Theme, Renderer>>,
-) -> DropdownMenuItem<'a, M> {
+    content: impl Into<Element<'a, Message, Theme, Renderer>>,
+) -> DropdownMenuItem<'a, Message> {
     Item::new(content)
 }
 
-pub fn dropdown_menu_option<'a, M: Clone + 'a>(
-    _theme: &Theme,
-    label: impl Into<Element<'a, M, Theme, Renderer>>,
-    event: Option<M>,
-) -> DropdownMenuItem<'a, M> {
-    Item::new(button(label).on_press_maybe(event)).close_on_click(true)
+pub fn dropdown_menu_option<'a, Message: Clone + 'a>(
+    theme: &Theme,
+    text_label: &'static str,
+    event: Option<Message>,
+) -> DropdownMenuItem<'a, Message> {
+    Item::new(
+        button(ellipsized_text(text_label).color(theme.palette.text))
+            .on_press_maybe(event)
+            .width(Length::Fill)
+            .style(catalog::button::menu_option),
+    )
+    .close_on_click(true)
 }
 
-pub fn dropdown_submenu<'a, M>(
+pub fn dropdown_submenu<'a, Message>(
     _theme: &Theme,
-    content: impl Into<Element<'a, M, Theme, Renderer>>,
-    submenu: DropdownMenu<'a, M>,
-) -> DropdownMenuItem<'a, M> {
+    content: impl Into<Element<'a, Message, Theme, Renderer>>,
+    submenu: DropdownMenu<'a, Message>,
+) -> DropdownMenuItem<'a, Message> {
     Item::with_menu(content, submenu)
 }
 
-pub fn dropdown_menu_grouping_option<'a, M: Clone + 'a>(
-    _theme: &Theme,
-    label: impl Into<Element<'a, M, Theme, Renderer>>,
-    submenu: DropdownMenu<'a, M>,
-) -> DropdownMenuItem<'a, M> {
-    Item::with_menu(button(label), submenu)
+pub fn dropdown_menu_grouping_option<'a, Message: Clone + 'a>(
+    theme: &Theme,
+    text_label: &'static str,
+    submenu: DropdownMenu<'a, Message>,
+) -> DropdownMenuItem<'a, Message> {
+    Item::with_menu(
+        row![
+            button(ellipsized_text(text_label).color(theme.palette.text))
+                .width(Length::Fill)
+                .style(catalog::button::menu_option),
+            Space::new().width(Length::Fill),
+            icon(icons::CHEVRON_RIGHT)
+                .size(theme.sizes.font.caption)
+                .color(theme.palette.text)
+        ]
+        .align_y(alignment::Vertical::Center),
+        submenu,
+    )
 }
 
 pub fn menu_option<'a, Message>(


### PR DESCRIPTION
## Changes

- Added Edit > Manage tags Option in main menu.
- Added Tag Management Modal:
  - Added tag outcomes for tag and tag group creation and removal with soft deletion.
  - Added UI for adding tags and removing them.
- Enabled real time audio thread feature in cpal and increased audio thread callback buffer size.

## Additional notes

- Deferred for v2:
  - Error handling UI, duplicate tag names simply fail silently for now to ensure tagging system integrity.
  - Better styling.

## Screenshot
<img width="898" height="678" alt="image" src="https://github.com/user-attachments/assets/a334d9e2-c9b6-471a-abff-dfd3b30f724a" />
