### PR TITLE
feat(track-info-pane): add track information

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -170,7 +170,7 @@ impl App {
                 pane_split_ratio: PaneSplitPositions {
                     explorer_main: 0.2,
                     main_queue: 0.7,
-                    queue_track_information: 0.8,
+                    queue_track_information: 0.5,
                 },
 
                 playback_controller,

--- a/src/app.rs
+++ b/src/app.rs
@@ -182,7 +182,7 @@ impl App {
                 explorer_pane: ExplorerPane::default(),
                 main_pane: MainPane::default(),
                 queue_pane: QueuePane::default(),
-                track_information_pane: TrackInformationPane {},
+                track_information_pane: TrackInformationPane::default(),
                 status_bar: StatusBar {},
                 playback_bar: PlaybackBar::new(),
                 modal_controller: ModalController::default(),

--- a/src/ui/components/track_information_pane/handler.rs
+++ b/src/ui/components/track_information_pane/handler.rs
@@ -9,7 +9,7 @@ use crate::{
 impl App {
     pub fn view_track_information_pane(&self) -> Element<'_, app::Message, Theme, Renderer> {
         self.track_information_pane
-            .view(&self.theme)
+            .view(&self.theme, &self.tracks)
             .map(ui::Message::TrackInformationPane)
             .map(app::Message::Ui)
     }
@@ -39,7 +39,7 @@ impl App {
 
     pub fn notify_track_information_pane(&mut self, event: &Event) -> Task<app::Message> {
         self.track_information_pane
-            .on_event(event)
+            .on_event(event, &self.playback_owner)
             .map(ui::Message::TrackInformationPane)
             .map(app::Message::Ui)
     }

--- a/src/ui/components/track_information_pane/mod.rs
+++ b/src/ui/components/track_information_pane/mod.rs
@@ -1,15 +1,27 @@
 use iced::{
-    Element, Length, Renderer, Task,
-    widget::{container, text},
+    Element, Length, Renderer, Task, alignment,
+    widget::{Space, center, column, container, scrollable, text},
 };
+use rustc_hash::FxHashMap;
 use tracing::instrument;
 
-use crate::{event::Event, ui::theme::Theme};
+use crate::{
+    app::PlaybackOwner,
+    event::Event,
+    track::models::{Track, TrackId},
+    ui::{
+        components::track_information_pane::widgets::track_information,
+        theme::{Theme, catalog},
+    },
+};
 
 pub mod handler;
+pub mod widgets;
 
-#[derive(Debug)]
-pub struct TrackInformationPane {}
+#[derive(Debug, Default)]
+pub struct TrackInformationPane {
+    playing_track_id: Option<TrackId>,
+}
 
 #[derive(Debug, Clone)]
 pub enum Message {}
@@ -24,18 +36,56 @@ impl TrackInformationPane {
     }
 
     #[instrument(skip(self), level = "debug")]
-    pub fn on_event(&mut self, event: &Event) -> Task<Message> {
-        Task::none()
+    pub fn on_event(&mut self, event: &Event, playback_owner: &PlaybackOwner) -> Task<Message> {
+        let task = Task::none();
+
+        if !matches!(playback_owner, PlaybackOwner::PlaybackBar) {
+            return task;
+        }
+
+        #[allow(clippy::single_match)]
+        match event {
+            Event::ActiveTrackChanged(track_id) => {
+                self.playing_track_id = *track_id;
+            }
+            _ => {}
+        }
+
+        task
     }
 
-    pub fn view<'a>(&'a self, _theme: &Theme) -> Element<'a, Message, Theme, Renderer> {
-        container(text("Track Information Pane"))
-            .height(Length::FillPortion(3))
-            .width(Length::Fill)
-            .style(|theme: &Theme| container::Style {
-                background: Some(theme.palette.surface_raised.into()),
-                ..container::Style::default()
-            })
-            .into()
+    pub fn view<'a>(
+        &'a self,
+        theme: &Theme,
+        tracks: &'a FxHashMap<TrackId, Track>,
+    ) -> Element<'a, Message, Theme, Renderer> {
+        let track_information_labels = self
+            .playing_track_id
+            .and_then(|playing_track_id| tracks.get(&playing_track_id))
+            .map_or_else(
+                || Space::new().into(),
+                |track| track_information(theme, track),
+            );
+
+        container(
+            scrollable(
+                column![
+                    track_information_labels,
+                    center(text("No image").color(theme.palette.text_muted))
+                        .width(300)
+                        .height(300)
+                        .style(catalog::container::modal)
+                ]
+                .width(Length::Fill)
+                .align_x(alignment::Horizontal::Center)
+                .spacing(theme.sizes.space.xl)
+                .padding(theme.sizes.space.xl),
+            )
+            .style(catalog::scrollable::pane),
+        )
+        .height(Length::Fill)
+        .width(Length::Fill)
+        .style(catalog::container::background_surface_raised)
+        .into()
     }
 }

--- a/src/ui/components/track_information_pane/mod.rs
+++ b/src/ui/components/track_information_pane/mod.rs
@@ -74,7 +74,7 @@ impl TrackInformationPane {
                     center(text("No image").color(theme.palette.text_muted))
                         .width(300)
                         .height(300)
-                        .style(catalog::container::modal)
+                        .style(catalog::container::track_thumbnail)
                 ]
                 .width(Length::Fill)
                 .align_x(alignment::Horizontal::Center)

--- a/src/ui/components/track_information_pane/widgets.rs
+++ b/src/ui/components/track_information_pane/widgets.rs
@@ -1,0 +1,58 @@
+use iced::{
+    Element, Length, Renderer,
+    widget::{column, text},
+};
+
+use crate::{
+    track::{models::Track, utils::get_track_duration_label},
+    ui::{components::track_information_pane::Message, theme::Theme},
+};
+
+pub fn track_information<'a>(
+    theme: &Theme,
+    track: &'a Track,
+) -> Element<'a, Message, Theme, Renderer> {
+    let title = track.title.as_deref().unwrap_or("Untitled");
+    let artist = track.artist.as_deref().unwrap_or("Unknown");
+    let album = track.album.as_deref();
+    let year = track.year;
+    let file_extension = track.file_format.to_ascii_uppercase();
+    let sample_rate_khz = format!("{:.1} kHz", track.sample_rate as f32 / 1000.0);
+    let bitrate_kbps = track
+        .bitrate_kbps
+        .map(|bitrate_kbps| format!("{bitrate_kbps}k"));
+    let channels = match track.channels {
+        1 => "Mono",
+        2 => "Stereo",
+        _ => "Unsupported",
+    };
+    let duration = get_track_duration_label(track);
+
+    let mut secondary_track_information = vec![text(artist).size(theme.sizes.font.body).into()];
+
+    if let Some(album) = album {
+        secondary_track_information.push(text(album).size(theme.sizes.font.body).into());
+    }
+
+    if let Some(year) = year {
+        secondary_track_information.push(text(year).size(theme.sizes.font.body).into());
+    }
+
+    let track_file_information = bitrate_kbps.map_or_else(
+        || format!("{file_extension} {sample_rate_khz}, {channels}, {duration}"),
+        |bitrate_kbps| {
+            format!("{file_extension} {sample_rate_khz}, {bitrate_kbps}, {channels}, {duration}")
+        },
+    );
+
+    column![
+        text(title),
+        column(secondary_track_information).spacing(theme.sizes.space.md),
+        text(track_file_information)
+            .size(theme.sizes.font.small)
+            .color(theme.palette.text_muted)
+    ]
+    .width(Length::Fill)
+    .spacing(theme.sizes.space.lg)
+    .into()
+}

--- a/src/ui/theme/catalog/container.rs
+++ b/src/ui/theme/catalog/container.rs
@@ -125,3 +125,16 @@ pub fn active_badge(theme: &Theme) -> Style {
         ..Style::default()
     }
 }
+
+pub fn track_thumbnail(theme: &Theme) -> Style {
+    Style {
+        background: Some(theme.palette.surface.into()),
+        text_color: None,
+        border: Border {
+            color: theme.palette.border,
+            width: theme.sizes.border.width,
+            radius: Radius::from(theme.sizes.border.radius_sm),
+        },
+        ..Style::default()
+    }
+}


### PR DESCRIPTION
## Changes

- Added track information pane
- Changed initial Queue Pane - Track Information Pane split proportion when starting the app.

## Additional notes

- Loading track file thumbnails is deferred to v2.

## Screenshots
<img width="2555" height="1528" alt="image" src="https://github.com/user-attachments/assets/a16280e4-b8c5-4b05-b3bd-b0e8e428efba" />
